### PR TITLE
fix: isolate Frappe context for concurrent tools

### DIFF
--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -559,32 +559,93 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertFalse(proposal_tools.intersection(ask_tool_names))
 		self.assertFalse(host_mutation_tools.intersection(ask_tool_names))
 
-	def test_clear_messages_wrapper_connects_without_changing_user(self):
-		inherited_db = frappe.local.db
+	def test_tool_wrapper_uses_public_frappe_lifecycle_and_caller_identity(self):
+		parent_db = frappe.local.db
+		parent_message_log = frappe.local.message_log
+		caller = {
+			"site": frappe.local.site,
+			"sites_path": frappe.local.sites_path,
+			"user": frappe.session.user,
+			"language": frappe.local.lang,
+		}
+		parent_local_ids = {
+			"flags": id(frappe.local.flags),
+			"session": id(frappe.local.session),
+			"response": id(frappe.local.response),
+			"message_log": id(parent_message_log),
+		}
 		private_db = MagicMock()
+		events = []
+		original_init = frappe.init
+		original_set_user = frappe.set_user
+		original_destroy = frappe.destroy
+
+		private_db.commit.side_effect = lambda: events.append("commit")
+		private_db.close.side_effect = lambda: events.append("close")
+
+		def init(site, *, sites_path):
+			events.append("init")
+			original_init(site, sites_path=sites_path)
 
 		def connect(*, set_admin_as_user):
+			events.append("connect")
 			self.assertFalse(set_admin_as_user)
 			frappe.local.db = private_db
 
-		wrapped = clear_messages_on_tool_error(lambda: frappe.session.user)
+		def set_user(user):
+			events.append("set_user")
+			original_set_user(user)
+
+		def destroy():
+			events.append("destroy")
+			original_destroy()
+
+		def tool():
+			events.append("tool")
+			return {
+				"site": frappe.local.site,
+				"user": frappe.session.user,
+				"language": frappe.local.lang,
+				"local_ids": {
+					"flags": id(frappe.local.flags),
+					"session": id(frappe.local.session),
+					"response": id(frappe.local.response),
+					"message_log": id(frappe.local.message_log),
+				},
+			}
+
+		wrapped = clear_messages_on_tool_error(tool)
 		with (
-			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
-			patch("ask_alyf.ask_alyf.toolset.frappe.set_user") as set_user,
+			patch("ask_alyf.ask_alyf.toolset.frappe.init", side_effect=init) as init_mock,
+			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect) as connect_mock,
+			patch("ask_alyf.ask_alyf.toolset.frappe.set_user", side_effect=set_user) as set_user_mock,
+			patch("ask_alyf.ask_alyf.toolset.frappe.destroy", side_effect=destroy) as destroy_mock,
 		):
 			result = wrapped()
 
-		self.assertEqual(result, frappe.session.user)
-		set_user.assert_not_called()
-		private_db.commit.assert_called_once_with()
-		private_db.close.assert_called_once_with()
-		self.assertIs(frappe.local.db, inherited_db)
+		self.assertEqual(result["site"], caller["site"])
+		self.assertEqual(result["user"], caller["user"])
+		self.assertEqual(result["language"], caller["language"])
+		for key, parent_id in parent_local_ids.items():
+			self.assertNotEqual(result["local_ids"][key], parent_id)
+		self.assertEqual(events, ["init", "connect", "set_user", "tool", "commit", "destroy", "close"])
+		init_mock.assert_called_once_with(caller["site"], sites_path=caller["sites_path"])
+		connect_mock.assert_called_once_with(set_admin_as_user=False)
+		set_user_mock.assert_called_once_with(caller["user"])
+		destroy_mock.assert_called_once_with()
+		self.assertIs(frappe.local.db, parent_db)
+		self.assertIs(frappe.local.message_log, parent_message_log)
 
-	def test_clear_messages_wrapper_isolates_concurrent_copied_contexts(self):
-		inherited_db = frappe.local.db
-		inherited_currently_saving = list(frappe.local.flags.currently_saving)
-		inherited_response_docs = list(frappe.local.response.docs)
-		inherited_message_log = list(frappe.local.message_log)
+	def test_tool_wrapper_isolates_concurrent_copied_contexts(self):
+		parent_db = frappe.local.db
+		parent_flags = frappe.local.flags
+		parent_session = frappe.local.session
+		parent_response = frappe.local.response
+		parent_message_log = frappe.local.message_log
+		parent_currently_saving = list(parent_flags.currently_saving)
+		parent_response_docs = list(parent_response.docs)
+		parent_messages = list(parent_message_log)
+		parent_message_log.append("parent message")
 		connections = []
 		connection_barrier = threading.Barrier(2)
 		tool_barrier = threading.Barrier(2)
@@ -610,6 +671,12 @@ class UnitTestCodeTools(UnitTestCase):
 			tool_barrier.wait(timeout=5)
 			return {
 				"db": bound_db,
+				"local_ids": {
+					"flags": id(frappe.local.flags),
+					"session": id(frappe.local.session),
+					"response": id(frappe.local.response),
+					"message_log": id(frappe.local.message_log),
+				},
 				"currently_saving": list(frappe.local.flags.currently_saving),
 				"response_docs": list(frappe.local.response.docs),
 				"message_log": list(frappe.local.message_log),
@@ -618,83 +685,127 @@ class UnitTestCodeTools(UnitTestCase):
 		wrapped = clear_messages_on_tool_error(tool)
 		contexts = [contextvars.copy_context(), contextvars.copy_context()]
 
-		with (
-			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
-			ThreadPoolExecutor(max_workers=2) as executor,
-		):
-			futures = [executor.submit(context.run, wrapped) for context in contexts]
-			results = [future.result(timeout=5) for future in futures]
+		try:
+			with (
+				patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
+				ThreadPoolExecutor(max_workers=2) as executor,
+			):
+				futures = [executor.submit(context.run, wrapped) for context in contexts]
+				results = [future.result(timeout=5) for future in futures]
 
-		self.assertEqual(
-			{id(result["db"]) for result in results}, {id(connection) for connection in connections}
-		)
-		for result in results:
-			marker = id(result["db"])
-			self.assertEqual(result["currently_saving"], [*inherited_currently_saving, marker])
-			self.assertEqual(result["response_docs"], [*inherited_response_docs, marker])
-			self.assertEqual(result["message_log"], [*inherited_message_log, marker])
-		for connection in connections:
-			connection.commit.assert_called_once_with()
-			connection.close.assert_called_once_with()
-		self.assertIs(frappe.local.db, inherited_db)
-		self.assertNotIn("tool_marker", frappe.local.flags)
-		self.assertNotIn("tool_marker", frappe.local.session)
-		self.assertNotIn("tool_marker", frappe.local.response)
-		self.assertEqual(frappe.local.flags.currently_saving, inherited_currently_saving)
-		self.assertEqual(frappe.local.response.docs, inherited_response_docs)
-		self.assertEqual(frappe.local.message_log, inherited_message_log)
+			self.assertEqual(
+				{id(result["db"]) for result in results}, {id(connection) for connection in connections}
+			)
+			for result in results:
+				marker = id(result["db"])
+				self.assertEqual(result["currently_saving"], [marker])
+				self.assertEqual(result["response_docs"], [marker])
+				self.assertEqual(result["message_log"], [marker])
+			for key in ("flags", "session", "response", "message_log"):
+				self.assertEqual(len({result["local_ids"][key] for result in results}), 2)
+			for connection in connections:
+				connection.commit.assert_called_once_with()
+				connection.close.assert_called_once_with()
+			self.assertIs(frappe.local.db, parent_db)
+			self.assertIs(frappe.local.flags, parent_flags)
+			self.assertIs(frappe.local.session, parent_session)
+			self.assertIs(frappe.local.response, parent_response)
+			self.assertIs(frappe.local.message_log, parent_message_log)
+			self.assertEqual(parent_flags.currently_saving, parent_currently_saving)
+			self.assertEqual(parent_response.docs, parent_response_docs)
+			self.assertEqual(parent_message_log, [*parent_messages, "parent message"])
+		finally:
+			parent_message_log[:] = parent_messages
 
-	def test_clear_messages_wrapper_propagates_commit_failure(self):
-		inherited_db = frappe.local.db
+	def test_tool_wrapper_rolls_back_commit_failure_without_touching_parent_messages(self):
+		parent_db = frappe.local.db
+		parent_message_log = frappe.local.message_log
+		parent_messages = list(parent_message_log)
+		parent_message_log.append("parent message")
 		private_db = MagicMock()
 		private_db.commit.side_effect = RuntimeError("commit failed")
 
 		def connect(*, set_admin_as_user):
+			self.assertFalse(set_admin_as_user)
 			frappe.local.db = private_db
 
 		wrapped = clear_messages_on_tool_error(lambda: "done")
-		with (
-			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
-			patch("ask_alyf.ask_alyf.toolset.frappe.clear_messages") as clear_messages,
-			self.assertRaisesRegex(RuntimeError, "commit failed"),
-		):
-			wrapped()
+		try:
+			with (
+				patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
+				patch(
+					"ask_alyf.ask_alyf.toolset.frappe.clear_messages", wraps=frappe.clear_messages
+				) as clear_messages,
+				self.assertRaisesRegex(RuntimeError, "commit failed"),
+			):
+				wrapped()
 
-		private_db.rollback.assert_called_once_with()
-		private_db.close.assert_called_once_with()
-		clear_messages.assert_called_once_with()
-		self.assertIs(frappe.local.db, inherited_db)
+			private_db.rollback.assert_called_once_with()
+			private_db.close.assert_called_once_with()
+			clear_messages.assert_called_once_with()
+			self.assertIs(frappe.local.db, parent_db)
+			self.assertIs(frappe.local.message_log, parent_message_log)
+			self.assertEqual(parent_message_log, [*parent_messages, "parent message"])
+		finally:
+			parent_message_log[:] = parent_messages
 
-	def test_clear_messages_wrapper_preserves_async_tools(self):
+	def test_tool_wrapper_preserves_async_tools_and_context_across_await(self):
+		parent_db = frappe.local.db
+		private_db = MagicMock()
+
+		def connect(*, set_admin_as_user):
+			self.assertFalse(set_admin_as_user)
+			frappe.local.db = private_db
+
 		async def fake_tool(file_id):
+			private_state = (id(frappe.local.db), id(frappe.local.flags))
+			await asyncio.sleep(0)
+			self.assertEqual((id(frappe.local.db), id(frappe.local.flags)), private_state)
 			return {"file_id": file_id}
 
 		wrapped = clear_messages_on_tool_error(fake_tool)
-		result = asyncio.run(wrapped("FILE-0001"))
+		with patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect):
+			result = asyncio.run(wrapped("FILE-0001"))
 
 		self.assertTrue(asyncio.iscoroutinefunction(wrapped))
 		self.assertEqual(result, {"file_id": "FILE-0001"})
+		private_db.commit.assert_called_once_with()
+		private_db.close.assert_called_once_with()
+		self.assertIs(frappe.local.db, parent_db)
 
-	def test_clear_messages_wrapper_clears_messages_for_async_tool_errors(self):
+	def test_tool_wrapper_isolates_async_tool_errors_and_parent_messages(self):
+		parent_db = frappe.local.db
+		parent_message_log = frappe.local.message_log
+		parent_messages = list(parent_message_log)
+		parent_message_log.append("parent message")
+		private_db = MagicMock()
+
+		def connect(*, set_admin_as_user):
+			self.assertFalse(set_admin_as_user)
+			frappe.local.db = private_db
+
 		async def fake_tool():
 			frappe.local.message_log.append("tool message")
+			await asyncio.sleep(0)
 			raise RuntimeError("boom")
 
 		wrapped = clear_messages_on_tool_error(fake_tool)
-		inherited_message_log = frappe.local.message_log
-		original_messages = list(inherited_message_log)
-		inherited_message_log.append("parent message")
-
 		try:
-			with patch(
-				"ask_alyf.ask_alyf.toolset.frappe.clear_messages", wraps=frappe.clear_messages
-			) as clear_messages:
-				with self.assertRaisesRegex(RuntimeError, "boom"):
-					asyncio.run(wrapped())
+			with (
+				patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
+				patch(
+					"ask_alyf.ask_alyf.toolset.frappe.clear_messages", wraps=frappe.clear_messages
+				) as clear_messages,
+				self.assertRaisesRegex(RuntimeError, "boom"),
+			):
+				asyncio.run(wrapped())
 
+			private_db.commit.assert_not_called()
+			private_db.rollback.assert_called_once_with()
+			private_db.close.assert_called_once_with()
 			clear_messages.assert_called_once_with()
-			self.assertIs(frappe.local.message_log, inherited_message_log)
-			self.assertEqual(inherited_message_log, [*original_messages, "parent message"])
+			self.assertIs(frappe.local.db, parent_db)
+			self.assertIs(frappe.local.message_log, parent_message_log)
+			self.assertEqual(parent_message_log, [*parent_messages, "parent message"])
 		finally:
-			frappe.local.message_log = inherited_message_log
-			inherited_message_log[:] = original_messages
+			parent_message_log[:] = parent_messages

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -581,7 +581,6 @@ class UnitTestCodeTools(UnitTestCase):
 		original_destroy = frappe.destroy
 
 		private_db.commit.side_effect = lambda: events.append("commit")
-		private_db.close.side_effect = lambda: events.append("close")
 
 		def init(site, *, sites_path):
 			events.append("init")
@@ -628,11 +627,12 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertEqual(result["language"], caller["language"])
 		for key, parent_id in parent_local_ids.items():
 			self.assertNotEqual(result["local_ids"][key], parent_id)
-		self.assertEqual(events, ["init", "connect", "set_user", "tool", "commit", "destroy", "close"])
+		self.assertEqual(events, ["init", "connect", "set_user", "tool", "commit", "destroy"])
 		init_mock.assert_called_once_with(caller["site"], sites_path=caller["sites_path"])
 		connect_mock.assert_called_once_with(set_admin_as_user=False)
 		set_user_mock.assert_called_once_with(caller["user"])
 		destroy_mock.assert_called_once_with()
+		private_db.close.assert_called_once_with()
 		self.assertIs(frappe.local.db, parent_db)
 		self.assertIs(frappe.local.message_log, parent_message_log)
 
@@ -748,6 +748,34 @@ class UnitTestCodeTools(UnitTestCase):
 			self.assertEqual(parent_message_log, [*parent_messages, "parent message"])
 		finally:
 			parent_message_log[:] = parent_messages
+
+	def test_tool_wrapper_does_not_mask_tool_error_when_destroy_fails(self):
+		parent_db = frappe.local.db
+		private_db = MagicMock()
+		original_destroy = frappe.destroy
+
+		def connect(*, set_admin_as_user):
+			self.assertFalse(set_admin_as_user)
+			frappe.local.db = private_db
+
+		def destroy():
+			original_destroy()
+			raise RuntimeError("destroy failed")
+
+		def tool():
+			raise ValueError("tool failed")
+
+		wrapped = clear_messages_on_tool_error(tool)
+		with (
+			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
+			patch("ask_alyf.ask_alyf.toolset.frappe.destroy", side_effect=destroy),
+			self.assertRaisesRegex(ValueError, "tool failed"),
+		):
+			wrapped()
+
+		private_db.rollback.assert_called_once_with()
+		private_db.close.assert_called_once_with()
+		self.assertIs(frappe.local.db, parent_db)
 
 	def test_tool_wrapper_preserves_async_tools_and_context_across_await(self):
 		parent_db = frappe.local.db

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -1,5 +1,6 @@
+import asyncio
 import contextlib
-import copy
+import contextvars
 import functools
 import inspect
 from dataclasses import dataclass, field
@@ -16,16 +17,6 @@ from ask_alyf.ask_alyf.history import (
 )
 from ask_alyf.ask_alyf.skill_utils import get_accessible_skill_doc
 from ask_alyf.ask_alyf.utils import parse_newline_list
-
-# Frappe 16+ owns this ContextVar; Frappe 15 stores it inside Werkzeug's Local.
-# Neither version exposes a public API for temporarily rebinding frappe.local.
-try:
-	from frappe.utils.local import _contextvar as frappe_local_context
-except ImportError as exc:
-	try:
-		frappe_local_context = object.__getattribute__(frappe.local, "_Local__storage")
-	except AttributeError:
-		raise RuntimeError("Unsupported Frappe local implementation; update _isolated_db") from exc
 
 # Frappe list filters are a list of filter rows, where each row is a list of
 # scalars, e.g. [["Customer", "name", "=", "CUST-001"], ["disabled", "=", 0]].
@@ -1023,76 +1014,73 @@ class ask_alyfToolset:
 		)
 
 
+@dataclass(frozen=True)
+class _CallerFrappeContext:
+	site: str
+	sites_path: str
+	user: str
+	language: str
+
+
+def _capture_caller_frappe_context() -> _CallerFrappeContext:
+	return _CallerFrappeContext(
+		site=frappe.local.site,
+		sites_path=frappe.local.sites_path,
+		user=frappe.session.user,
+		language=frappe.local.lang,
+	)
+
+
 @contextlib.contextmanager
-def _isolated_db():
-	"""Run a block in a private Frappe local context and DB connection.
-
-	LangGraph runs sync tools via `asyncio.to_thread`, which copies the
-	calling context into the worker thread. Frappe stores one mutable dict
-	in a ContextVar, so copied contexts otherwise still share DB bindings.
-
-	This binds a new local dict and copies the mutable request state tools
-	commonly modify. Other inherited context values must be treated as
-	read-only. A private connection is opened and closed before restoring
-	the caller's ContextVar binding.
-	"""
-	private_local = dict(frappe_local_context.get({}))
-	for key in ("flags", "session", "response", "message_log", "error_log", "debug_log"):
-		if key in private_local:
-			private_local[key] = copy.deepcopy(private_local[key])
-	if "response_headers" in private_local:
-		private_local["response_headers"] = private_local["response_headers"].copy()
-
-	local_token = frappe_local_context.set(private_local)
+def _private_frappe_context(caller: _CallerFrappeContext):
+	"""Initialize and destroy a private Frappe context for one tool call."""
 	private_db = None
 	try:
-		conf = getattr(frappe.local, "conf", None)
-		if not conf or not getattr(conf, "db_name", None):
-			yield
-			return
-
+		frappe.init(caller.site, sites_path=caller.sites_path)
 		frappe.connect(set_admin_as_user=False)
 		private_db = frappe.local.db
+		frappe.set_user(caller.user)
+		frappe.local.lang = caller.language
 		yield
 		private_db.commit()
-	except Exception:
+	except BaseException:
 		if private_db is not None:
 			with contextlib.suppress(Exception):
 				private_db.rollback()
 		frappe.clear_messages()
 		raise
 	finally:
-		if private_db is not None:
-			with contextlib.suppress(Exception):
-				private_db.close()
-		frappe_local_context.reset(local_token)
+		frappe.destroy()
 
 
 def clear_messages_on_tool_error(func):
-	"""Wrap a tool so each call runs on a private DB connection and queued
-	Frappe messages are discarded on exception.
-
-	The private connection (see `_isolated_db`) is what makes tool calls
-	safe under LangGraph's threaded tool executor; the error handling keeps
-	user-facing popups from firing when a tool fails inside the agent loop.
-	"""
+	"""Run each tool call in a fresh Frappe context and DB connection."""
 
 	if inspect.iscoroutinefunction(func):
 
 		@functools.wraps(func)
 		async def async_wrapper(*args, **kwargs):
-			with _isolated_db():
-				return await func(*args, **kwargs)
+			caller = _capture_caller_frappe_context()
+			return await asyncio.create_task(
+				_run_async_with_private_frappe_context(caller, func, args, kwargs),
+				context=contextvars.Context(),
+			)
 
 		return async_wrapper
 
 	@functools.wraps(func)
 	def wrapper(*args, **kwargs):
-		return _run_with_isolated_db(func, args, kwargs)
+		caller = _capture_caller_frappe_context()
+		return contextvars.Context().run(_run_with_private_frappe_context, caller, func, args, kwargs)
 
 	return wrapper
 
 
-def _run_with_isolated_db(func, args, kwargs):
-	with _isolated_db():
+def _run_with_private_frappe_context(caller, func, args, kwargs):
+	with _private_frappe_context(caller):
 		return func(*args, **kwargs)
+
+
+async def _run_async_with_private_frappe_context(caller, func, args, kwargs):
+	with _private_frappe_context(caller):
+		return await func(*args, **kwargs)

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -1050,7 +1050,8 @@ def _private_frappe_context(caller: _CallerFrappeContext):
 		frappe.clear_messages()
 		raise
 	finally:
-		frappe.destroy()
+		with contextlib.suppress(Exception):
+			frappe.destroy()
 
 
 def clear_messages_on_tool_error(func):


### PR DESCRIPTION
Run each tool with its own Frappe context and database connection.
Prevent identity, messages, and mutable state from leaking between calls.
