### PR TITLE
fix: use responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Common settings include:
 - _Excluded DocTypes_
 - separate vision model settings, if document and image extraction should use a different model
 
+Ask ALYF chat requires the [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses). OpenAI-compatible _Base URLs_ must implement `POST /v1/responses`. Providers that support only Chat Completions are not supported for chat.
+
 ## Conversation History
 
 Conversations are stored in the **Ask ALYF Conversation** DocType, which keeps messages available across page reloads and provides an audit trail for Agent mode proposals and actions.

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -108,6 +108,7 @@ def build_chat_model(settings, *, temperature: float = 0.2) -> ChatOpenAI:
 		api_key=_get_api_key_from_settings(settings),
 		base_url=(settings.base_url or "").strip() or None,
 		temperature=temperature,
+		use_responses_api=True,
 	)
 
 
@@ -327,18 +328,8 @@ Mode awareness and behavior:
 		self.runtime.conversation_history = conversation_history or []
 		input_messages = self._build_input_messages(message)
 		result = self.agent.invoke({"messages": input_messages})
-		response_text = ""
 		result_messages = result.get("messages") if isinstance(result, dict) else None
-		if result_messages:
-			last = result_messages[-1]
-			content = getattr(last, "content", None)
-			if isinstance(content, str):
-				response_text = content.strip()
-			elif content is None:
-				response_text = ""
-			else:
-				# Some providers return content as a list of blocks; coerce to text.
-				response_text = str(content).strip()
+		response_text = result_messages[-1].text.strip() if result_messages else ""
 
 		return {
 			"response": response_text,

--- a/ask_alyf/ask_alyf/field_agent.py
+++ b/ask_alyf/ask_alyf/field_agent.py
@@ -151,12 +151,6 @@ def run_field_agent(
 
 	result_messages = result.get("messages") if isinstance(result, dict) else None
 	if result_messages:
-		last = result_messages[-1]
-		content = getattr(last, "content", None)
-		if isinstance(content, str):
-			return content.strip()
-		elif content is not None:
-			# Some providers return content as a list of blocks; coerce to text.
-			return str(content).strip()
+		return result_messages[-1].text.strip()
 
 	return ""

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -10,7 +10,7 @@ from frappe.tests import UnitTestCase
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from ask_alyf.ask_alyf import tools
-from ask_alyf.ask_alyf.agent import ASK_ALYF_EXCLUDED_TOOLS, ask_alyfAgentRunner
+from ask_alyf.ask_alyf.agent import ASK_ALYF_EXCLUDED_TOOLS, ask_alyfAgentRunner, build_chat_model
 from ask_alyf.ask_alyf.history import history_item_to_native_message
 from ask_alyf.ask_alyf.toolset import ask_alyfToolset, clear_messages_on_tool_error
 
@@ -52,6 +52,11 @@ class UnitTestCodeTools(UnitTestCase):
 		runner.settings = FakeSettings(allow_code_search=allow_code_search)
 		runner.toolset = ask_alyfToolset(runtime, settings=runner.settings)
 		return runner
+
+	def test_build_chat_model_uses_responses_api_for_any_model(self):
+		model = build_chat_model(FakeSettings(allow_code_search=False))
+
+		self.assertTrue(model.use_responses_api)
 
 	def test_subagents_register_source_code_analyzer_only_when_code_search_enabled(self):
 		raw_code_tool_names = {"search_code", "read_code_file", "ls", "find", "grep"}
@@ -532,13 +537,27 @@ class UnitTestCodeTools(UnitTestCase):
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")
 		runner.agent = SimpleNamespace(
-			invoke=lambda _input, config=None: {"messages": [SimpleNamespace(content="Done.")]}
+			invoke=lambda _input, config=None: {"messages": [AIMessage(content="Done.")]}
 		)
 		result = runner.run("do something", conversation_history=[])
 		self.assertEqual(result["response"], "Done.")
 		self.assertEqual(result["pending_operations"], [])
 		self.assertEqual(result["document_extractions"], [])
 		self.assertEqual(result["attached_files"], [])
+
+	def test_run_extracts_text_from_responses_api_content_blocks(self):
+		runner = self.make_runner(allow_code_search=False)
+		response = AIMessage(
+			content=[
+				{"type": "reasoning", "summary": [], "content": [], "encrypted_content": "secret"},
+				{"type": "text", "text": ":)", "annotations": [], "phase": "final_answer"},
+			]
+		)
+		runner.agent = SimpleNamespace(invoke=lambda _input, config=None: {"messages": [response]})
+
+		result = runner.run("hello", conversation_history=[])
+
+		self.assertEqual(result["response"], ":)")
 
 	def test_agent_mode_tools_include_proposals_but_no_host_mutation_or_shell(self):
 		"""Model-visible tools must contain proposal operations but no direct

--- a/ask_alyf/ask_alyf/test_field_agent.py
+++ b/ask_alyf/ask_alyf/test_field_agent.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import frappe
 from frappe.tests import UnitTestCase
+from langchain_core.messages import AIMessage
 
 from ask_alyf.ask_alyf import api, field_contexts
 from ask_alyf.ask_alyf.api import _truncate_doc_for_size
@@ -67,7 +68,7 @@ class UnitTestFieldAgent(UnitTestCase):
 	def _make_fake_agent(self, output: str = "OK"):
 		"""Build a fake stateless agent whose `invoke` returns a native message list."""
 		agent = MagicMock()
-		agent.invoke.return_value = {"messages": [SimpleNamespace(content=output)]}
+		agent.invoke.return_value = {"messages": [AIMessage(content=output)]}
 		return agent
 
 	def test_run_field_agent_creates_no_conversation(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "langchain>=1.3.14,<2.0.0",
     "langchain-core>=1.4.9,<2.0.0",
     "langgraph>=1.2.5,<1.3.0",
-    "langchain-openai==1.3.5",
+    "langchain-openai==1.4.1",
     "pymupdf",
 ]
 


### PR DESCRIPTION
Use the OpenAI Responses API for model calls and upgrade `langchain-openai`, avoiding model-specific handling for reasoning models with tools. Extract output through `AIMessage.text` so structured reasoning metadata never appears in chat responses.