### PR TITLE
feat: filter and validate selected models using litellm

### DIFF
--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
@@ -89,6 +89,29 @@ class AskALYFSettings(Document):
 	def is_code_search_enabled(self) -> bool:
 		return bool(self.allow_code_search)
 
+	def validate(self):
+		validate_model_selection(
+			self.model,
+			ModelConfiguration.CHAT,
+			unsupported_message=_("The selected Chat Model ({0}) does not support function calling."),
+		)
+
+		if self.vision_model_is_chat_model:
+			validate_model_selection(
+				self.model,
+				ModelConfiguration.VISION,
+				unsupported_message=_(
+					"The selected Chat Model ({0}) does not support vision. Choose a vision-capable chat model or configure a separate vision model."
+				),
+			)
+			return
+
+		validate_model_selection(
+			self.vision_model,
+			ModelConfiguration.VISION,
+			unsupported_message=_("The selected Vision Model ({0}) does not support vision."),
+		)
+
 
 @frappe.whitelist()
 def get_available_models(configuration: str = ModelConfiguration.CHAT) -> list[dict[str, str]]:
@@ -166,6 +189,22 @@ def normalize_api_key(api_key: str | None) -> str:
 		return ""
 
 	return api_key
+
+
+def validate_model_selection(
+	model_id: str | None,
+	configuration: ModelConfiguration,
+	*,
+	unsupported_message: str,
+) -> None:
+	model_id = (model_id or "").strip()
+	if not model_id:
+		return
+
+	if is_available_model(model_id, configuration):
+		return
+
+	frappe.throw(unsupported_message.format(model_id))
 
 
 def is_text_generation_model(model_id: str) -> bool:

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 import frappe
@@ -13,13 +14,19 @@ if TYPE_CHECKING:
 		AskALYFExcludedDocType,
 	)
 
+
+class ModelConfiguration(StrEnum):
+	CHAT = "chat"
+	VISION = "vision"
+
+
 MODEL_CONFIG_FIELDS = {
-	"chat": {
+	ModelConfiguration.CHAT: {
 		"provider_field": "llm_provider",
 		"base_url_field": "base_url",
 		"api_key_field": "api_key",
 	},
-	"vision": {
+	ModelConfiguration.VISION: {
 		"provider_field": "vision_llm_provider",
 		"base_url_field": "vision_base_url",
 		"api_key_field": "vision_api_key",
@@ -81,7 +88,8 @@ class AskALYFSettings(Document):
 
 
 @frappe.whitelist()
-def get_available_models(configuration: str = "chat") -> list[dict[str, str]]:
+def get_available_models(configuration: str = ModelConfiguration.CHAT) -> list[dict[str, str]]:
+	configuration = parse_model_configuration(configuration)
 	settings = frappe.get_single("Ask ALYF Settings")
 	settings.check_permission("write")
 
@@ -121,12 +129,20 @@ def get_available_models(configuration: str = "chat") -> list[dict[str, str]]:
 	return [{"id": model.id} for model in models]
 
 
-def get_model_config_fields(configuration: str) -> dict[str, str]:
-	configuration = (configuration or "chat").strip().lower()
-	if configuration not in MODEL_CONFIG_FIELDS:
+def parse_model_configuration(
+	configuration: str | ModelConfiguration | None = None,
+) -> ModelConfiguration:
+	if isinstance(configuration, ModelConfiguration):
+		return configuration
+
+	try:
+		return ModelConfiguration((configuration or ModelConfiguration.CHAT).strip().lower())
+	except ValueError:
 		frappe.throw(_("Unsupported model configuration: {0}").format(configuration))
 
-	return MODEL_CONFIG_FIELDS[configuration]
+
+def get_model_config_fields(configuration: str | ModelConfiguration) -> dict[str, str]:
+	return MODEL_CONFIG_FIELDS[parse_model_configuration(configuration)]
 
 
 def get_any_llm_provider(llm_provider: str) -> str:

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
@@ -5,6 +5,7 @@ import frappe
 from any_llm import AnyLLM
 from frappe import _
 from frappe.model.document import Document
+from litellm.utils import get_model_info, supports_function_calling, supports_vision
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.has_role.has_role import HasRole
@@ -32,6 +33,8 @@ MODEL_CONFIG_FIELDS = {
 		"api_key_field": "vision_api_key",
 	},
 }
+
+LITELLM_PROVIDER = "openai"
 
 NON_TEXT_MODEL_PATTERNS = (
 	"audio",
@@ -122,7 +125,7 @@ def get_available_models(configuration: str = ModelConfiguration.CHAT) -> list[d
 	)
 	response = client.list_models()
 	models = sorted(
-		[model for model in response if is_text_generation_model(model.id)],
+		[model for model in response if is_available_model(model.id, configuration)],
 		key=lambda model: model.id.lower(),
 	)
 
@@ -171,3 +174,33 @@ def is_text_generation_model(model_id: str) -> bool:
 		return False
 
 	return not any(pattern in model_id for pattern in NON_TEXT_MODEL_PATTERNS)
+
+
+def is_litellm_mapped_model(model_id: str) -> bool:
+	try:
+		get_model_info(model_id, custom_llm_provider=LITELLM_PROVIDER)
+	except Exception:
+		return False
+
+	return True
+
+
+def has_required_capability(model_id: str, configuration: ModelConfiguration) -> bool:
+	match configuration:
+		case ModelConfiguration.CHAT:
+			supported = supports_function_calling(model_id, custom_llm_provider=LITELLM_PROVIDER)
+		case ModelConfiguration.VISION:
+			supported = supports_vision(model_id, custom_llm_provider=LITELLM_PROVIDER)
+
+	if supported:
+		return True
+
+	# LiteLLM returns False for unmapped custom models; keep those selectable.
+	return not is_litellm_mapped_model(model_id)
+
+
+def is_available_model(model_id: str, configuration: str | ModelConfiguration) -> bool:
+	if not is_text_generation_model(model_id):
+		return False
+
+	return has_required_capability(model_id, parse_model_configuration(configuration))

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
@@ -144,6 +144,86 @@ class UnitTestAskALYFSettings(UnitTestCase):
 			ask_alyf_settings.ModelConfiguration.VISION,
 		)
 
+	def test_validate_rejects_known_chat_model_without_function_calling(self):
+		settings = ask_alyf_settings.AskALYFSettings(
+			{
+				"doctype": "Ask ALYF Settings",
+				"model": "gpt-5-chat",
+			}
+		)
+
+		with patch.object(ask_alyf_settings, "is_available_model", return_value=False):
+			with self.assertRaises(frappe.ValidationError):
+				settings.validate()
+
+	def test_validate_rejects_known_chat_model_without_vision_when_shared(self):
+		settings = ask_alyf_settings.AskALYFSettings(
+			{
+				"doctype": "Ask ALYF Settings",
+				"vision_model_is_chat_model": 1,
+				"model": "gpt-audio",
+			}
+		)
+
+		with patch.object(
+			ask_alyf_settings,
+			"is_available_model",
+			side_effect=lambda model_id, configuration: (
+				configuration == ask_alyf_settings.ModelConfiguration.CHAT
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				settings.validate()
+
+	def test_validate_allows_unknown_chat_model_when_shared(self):
+		settings = ask_alyf_settings.AskALYFSettings(
+			{
+				"doctype": "Ask ALYF Settings",
+				"vision_model_is_chat_model": 1,
+				"model": "custom-local-model",
+			}
+		)
+
+		with patch.object(ask_alyf_settings, "is_available_model", return_value=True):
+			settings.validate()
+
+	def test_validate_rejects_known_vision_model_without_vision_support(self):
+		settings = ask_alyf_settings.AskALYFSettings(
+			{
+				"doctype": "Ask ALYF Settings",
+				"vision_model_is_chat_model": 0,
+				"model": "gpt-4o",
+				"vision_model": "gpt-audio",
+			}
+		)
+
+		with patch.object(
+			ask_alyf_settings,
+			"is_available_model",
+			side_effect=lambda model_id, configuration: (
+				configuration == ask_alyf_settings.ModelConfiguration.CHAT
+			),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				settings.validate()
+
+	def test_validate_skips_vision_model_check_when_separate_vision_model_is_not_set(self):
+		settings = ask_alyf_settings.AskALYFSettings(
+			{
+				"doctype": "Ask ALYF Settings",
+				"vision_model_is_chat_model": 0,
+				"model": "gpt-4o",
+			}
+		)
+
+		with patch.object(ask_alyf_settings, "is_available_model", return_value=True) as availability_check:
+			settings.validate()
+
+		availability_check.assert_called_once_with(
+			"gpt-4o",
+			ask_alyf_settings.ModelConfiguration.CHAT,
+		)
+
 
 class IntegrationTestAskALYFSettings(IntegrationTestCase):
 	"""

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
@@ -102,6 +102,12 @@ class UnitTestAskALYFSettings(UnitTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			ask_alyf_settings.get_model_config_fields("audio")
 
+	def test_parse_model_configuration_accepts_string_values(self):
+		self.assertEqual(
+			ask_alyf_settings.parse_model_configuration("vision"),
+			ask_alyf_settings.ModelConfiguration.VISION,
+		)
+
 
 class IntegrationTestAskALYFSettings(IntegrationTestCase):
 	"""

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/test_ask_alyf_settings.py
@@ -102,6 +102,42 @@ class UnitTestAskALYFSettings(UnitTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			ask_alyf_settings.get_model_config_fields("audio")
 
+	def test_is_available_model_filters_known_models_without_required_capability(self):
+		with patch.object(ask_alyf_settings, "supports_function_calling", return_value=False):
+			with patch.object(ask_alyf_settings, "is_litellm_mapped_model", return_value=True):
+				self.assertFalse(
+					ask_alyf_settings.is_available_model(
+						"gpt-5-chat", ask_alyf_settings.ModelConfiguration.CHAT
+					)
+				)
+
+	def test_is_available_model_keeps_unknown_models_for_chat_configuration(self):
+		with patch.object(ask_alyf_settings, "supports_function_calling", return_value=False):
+			with patch.object(ask_alyf_settings, "is_litellm_mapped_model", return_value=False):
+				self.assertTrue(
+					ask_alyf_settings.is_available_model(
+						"custom-local-model", ask_alyf_settings.ModelConfiguration.CHAT
+					)
+				)
+
+	def test_is_available_model_requires_vision_capability_for_vision_configuration(self):
+		with patch.object(ask_alyf_settings, "supports_vision", return_value=False):
+			with patch.object(ask_alyf_settings, "is_litellm_mapped_model", return_value=True):
+				self.assertFalse(
+					ask_alyf_settings.is_available_model(
+						"gpt-4.1-mini", ask_alyf_settings.ModelConfiguration.VISION
+					)
+				)
+
+	def test_is_available_model_keeps_unknown_models_for_vision_configuration(self):
+		with patch.object(ask_alyf_settings, "supports_vision", return_value=False):
+			with patch.object(ask_alyf_settings, "is_litellm_mapped_model", return_value=False):
+				self.assertTrue(
+					ask_alyf_settings.is_available_model(
+						"custom-vision-model", ask_alyf_settings.ModelConfiguration.VISION
+					)
+				)
+
 	def test_parse_model_configuration_accepts_string_values(self):
 		self.assertEqual(
 			ask_alyf_settings.parse_model_configuration("vision"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langchain-core>=1.4.9,<2.0.0",
     "langgraph>=1.2.5,<1.3.0",
     "langchain-openai==1.4.1",
+    "litellm>=1.83.0",
     "pymupdf",
 ]
 


### PR DESCRIPTION
Uses LiteLLM capability metadata to improve model selection in **Ask ALYF Settings**.

- Filters model picker options by capability: chat models require function calling, vision models require vision support
- Keeps unknown/custom models selectable when LiteLLM has no mapping
- Validates selected models on save (including manual autocomplete overrides)
- When _Use Chat Model for Vision_ is enabled, the chat model must support both function calling and vision
- Introduces `ModelConfiguration` enum and adds `litellm` as a direct dependency
