### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Ask ALYF
+
+Ask ALYF is a Frappe Framework app that adds an AI assistant to ERPNext/Frappe Desk. See `README.md` for the product overview, configuration, and tool reference.
+
+## Cursor Cloud specific instructions
+
+The dev environment is defined entirely by committed repo files — treat these as the source of truth and edit them (not a snapshot) when the environment must change:
+
+- `.cursor/environment.json` — wires the Dockerfile, the `install` hook (`.cursor/install.sh`), the `start` hook (`.cursor/start.sh`), and the `bench` terminal.
+- `.cursor/Dockerfile` — base image: Python 3.14 + 3.12 via pyenv, Node 24 + 22 via nvm, MariaDB server, Redis server, wkhtmltopdf, and Frappe/PDF build libs. **Hard requirement:** the app needs Python 3.14 and Node 24 (`pyproject.toml` sets `requires-python = ">=3.14"`; Frappe `version-16`'s `package.json` requires `node >=24`). A stock image with older Python/Node will fail.
+- `.cursor/install.sh` — creates the bench at `$HOME/frappe-bench`, starts MariaDB/Redis, creates the DB root user, runs `bench init` (Frappe `version-16`), soft-links this repo as the `ask_alyf` app, creates site `ask-alyf.localhost`, installs the app, enables `developer_mode`/`allow_tests`, builds assets, and migrates.
+
+Non-obvious caveats:
+
+- The bench lives at `$HOME/frappe-bench`; the app is **soft-linked** from the repo checkout into `apps/ask_alyf`, so repo edits are live in the bench (no reinstall needed).
+- Default site is `ask-alyf.localhost` (derived from the repo name); admin password is `admin`. The DB root user is `frappe`/`frappe`.
+- Run the stack from `$HOME/frappe-bench` with `bench start` (web on `:8000`, socketio on `:9000`). The committed `bench` terminal runs `.cursor/start.sh` (starts MariaDB + Redis) then `bench start`. MariaDB/Redis are local services, not external.
+- Lint: `pre-commit run --all-files` from the repo root (ruff, ruff-format, prettier, eslint). `commitlint` only runs on the `commit-msg` stage.
+- Tests: `bench --site ask-alyf.localhost run-tests --app ask_alyf` (needs `allow_tests` + `developer_mode`, both set by `install.sh`). CI mirrors this in `.github/workflows/ci.yml`.
+- **The AI chat requires network egress to `api.openai.com`, which is NOT in the default Cursor Cloud egress allowlist.** Configure the OpenAI key in **Ask ALYF Settings** (`api_key`, `model` e.g. `gpt-4o-mini`, `enabled=1`) or via the `OPENAI_API_KEY` secret. Without the egress allowance the full pipeline runs but the OpenAI Responses API call fails with `openai.APIConnectionError`; the chat then shows the graceful fallback "I hit an error while processing that request." Ask the user to add `api.openai.com` to the environment's egress allowlist for real chat.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified a full development environment for the `ask_alyf` Frappe app in Cursor Cloud, and captured the durable, non-obvious startup/run caveats in a new `AGENTS.md`.

This run booted as a just-in-time override (no linked environment / no build), so the committed `.cursor/Dockerfile` was not applied. I bootstrapped a functionally-equivalent bench in the VM (Python 3.14, Node 24, MariaDB, Redis, Frappe `version-16`) to prove the setup works end to end. The environment itself remains defined by the committed repo files (`.cursor/environment.json` → `Dockerfile` + `install.sh` + `start.sh`); no environment/snapshot changes are made here.

## What was verified

- **Lint** — `pre-commit run --all-files`: ruff, ruff-format, prettier, eslint all pass.
- **Tests** — `bench --site ask-alyf.localhost run-tests --app ask_alyf`: `Ran 109 tests ... OK`.
- **App running** — `bench start` (web `:8000`, socketio `:9000`); `/api/method/ping` → `pong`; login page renders.
- **Hello-world chat** — logged into Desk as Administrator, opened the Ask ALYF assistant, sent a message. The full pipeline (frontend → `send_message` → RQ worker → LangChain coordinator → OpenAI Responses API) runs; the worker issues `POST https://api.openai.com/v1/responses`.

## Known blocker (environment, not code)

The AI chat requires network egress to `api.openai.com`, which is **not** in the default Cursor Cloud egress allowlist. The external LLM call fails with `openai.APIConnectionError: Connection error`, and the chat shows the graceful fallback "I hit an error while processing that request." Adding `api.openai.com` to the egress allowlist unblocks real chat responses.

## Changes

- Add `AGENTS.md` documenting the app, the repo-defined environment, and Cloud-specific run caveats (Python 3.14 / Node 24 requirement, bench location + site name, run/lint/test commands, and the `api.openai.com` egress requirement).

## Artifacts

[Ask ALYF assistant open on Frappe Desk](https://cursor.com/agents/bc-0f1cff56-6c55-4624-9454-aee17068b840/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_ask_alyf_panel_open.webp)
[Chat message processed end-to-end (LLM call blocked by egress)](https://cursor.com/agents/bc-0f1cff56-6c55-4624-9454-aee17068b840/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_ask_alyf_message_processed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f1cff56-6c55-4624-9454-aee17068b840?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f1cff56-6c55-4624-9454-aee17068b840&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

