### PR TITLE
fix: keep exact values on single-value bar charts

### DIFF
--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -20,8 +20,8 @@ import "./field_agent";
 	}
 
 	/**
-	 * Frappe Charts divides by labels.length, Y interval range, and (for pie) grand total;
-	 * tiny/negative plot height or zero Y range yields NaN axis lines in draw.js.
+	 * Frappe Charts divides by labels.length and (for pie) grand total;
+	 * tiny/negative plot height yields NaN axis lines in draw.js.
 	 */
 	function normalizeStoredFrappeChartOptions(out) {
 		if (!out || typeof out !== "object") {
@@ -78,27 +78,6 @@ import "./field_agent";
 			const grandTotal = perSlice.reduce((acc, value) => acc + value, 0);
 			if (grandTotal <= 0) {
 				return { ok: false };
-			}
-		} else {
-			const allY = [];
-			for (const ds of out.data.datasets) {
-				for (const v of ds.values) {
-					if (Number.isFinite(v)) {
-						allY.push(v);
-					}
-				}
-			}
-			if (allY.length) {
-				const yMin = Math.min(...allY);
-				const yMax = Math.max(...allY);
-				if (yMin === yMax) {
-					const lastDs = out.data.datasets[out.data.datasets.length - 1];
-					const lastIdx = lastDs.values.length - 1;
-					if (lastIdx >= 0) {
-						const bump = yMax === 0 ? 1 : Math.abs(yMax) * 0.01 || 0.01;
-						lastDs.values[lastIdx] = yMax + bump;
-					}
-				}
 			}
 		}
 

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -79,6 +79,19 @@ import "./field_agent";
 			if (grandTotal <= 0) {
 				return { ok: false };
 			}
+		} else if (type === "line") {
+			const allY = out.data.datasets.flatMap((ds) => ds.values);
+			const yMin = Math.min(...allY);
+			const yMax = Math.max(...allY);
+			if (allY.length && yMin === yMax) {
+				// Line charts fit the axis to min/max. A flat series sits on the
+				// x-axis because frappe-charts expands a zero range upward only.
+				const pad = yMax === 0 ? 1 : Math.abs(yMax) * 0.1 || 0.1;
+				out.axisOptions = {
+					...out.axisOptions,
+					yAxisRange: { min: yMax - pad, max: yMax + pad },
+				};
+			}
 		}
 
 		const height = Number(out.height);


### PR DESCRIPTION
Resolves #100

## Summary
- Stop rewriting the last Y value when every value is the same.
- A bar of 1 stays 1. Frappe Charts already gives axis charts a non-zero Y range.

## Why we can drop the else branch

The else branch ran for bar, line, scatter, and mixed charts. When every Y value was equal, it increased the last value by 1 percent. If the value was 0, it added 1. The intent was to avoid a zero Y range. Frappe Charts divides plot height by the Y interval range. A range of 0 can yield NaN SVG attributes.

That rewrite changed real data. A bar chart with a value of 1 showed 1.01 on the bar and in the tooltip.

The bump is not needed for bar charts. Frappe Charts passes `withMinimum` only when the type is line. Bar, scatter, and mixed charts start the Y axis at 0. A series of all 1s already has a range from 0 to 1. The scale multiplier is finite.

Frappe Charts also handles a true zero interval range. `getChartRangeIntervals` has a special case for `range === 0`. It builds five ticks of size 1. The axis expands. The data stays the same.

Pie, donut, and percentage charts still reject a grand total of 0 in the remaining `if` branch. Height clamping still blocks NaN from a plot that is too short.

## Test plan
- [x] Show a bar chart with a single value of 1. The bar and tooltip show 1, not 1.01.
- [x] Show a bar chart with several equal non-zero values. The values stay exact.
- [x] Show a bar chart of all zeros. The chart still renders.
- [x] Show a pie chart with a positive total. It still renders.
- [x] Confirm a pie chart with total 0 still does not render.