### PR TITLE
feat: Checkpointer

### DIFF
--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -18,6 +18,7 @@ from langchain_core.messages import AnyMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 
 from ask_alyf.ask_alyf import tools
+from ask_alyf.ask_alyf.checkpointer import FrappeCheckpointSaver
 from ask_alyf.ask_alyf.deep_agent_backend import build_ask_alyf_backend
 from ask_alyf.ask_alyf.history import history_item_to_native_message
 from ask_alyf.ask_alyf.skill_utils import build_available_skills_instruction
@@ -125,6 +126,7 @@ class ask_alyfAgentRunner:
 		self.model = build_chat_model(self.settings, temperature=0.2)
 		app_roots = tools.get_installed_app_roots() if self.settings.is_code_search_enabled() else {}
 		self.backend = build_ask_alyf_backend(app_roots)
+		self.checkpointer = FrappeCheckpointSaver()
 		self.agent = create_deep_agent(
 			model=self.model,
 			tools=self._build_tools(),
@@ -133,8 +135,14 @@ class ask_alyfAgentRunner:
 			subagents=self._build_subagents(),
 			permissions=self._build_permissions(),
 			middleware=[build_tool_error_middleware()],
+			checkpointer=self.checkpointer,
 			name="ask_alyf",
 		)
+
+	@property
+	def thread_config(self) -> dict[str, Any]:
+		"""Graph config that ties this run to the conversation's stored state."""
+		return {"configurable": {"thread_id": self.runtime.conversation_name}}
 
 	def _can_write_skill(self) -> bool:
 		return bool(frappe.has_permission("Ask ALYF Skill", ptype="create"))
@@ -312,10 +320,17 @@ Mode awareness and behavior:
 	def _build_input_messages(self, message: str) -> list[AnyMessage]:
 		"""Build the native message list for the next invocation.
 
-		Without a checkpointer, the full stored history is rebuilt as native
-		messages each time and the new user message is appended.
+		The checkpointer restores what the agent saw and did in earlier turns,
+		so a conversation with stored state only receives what is new to it:
+		the stored items that follow the last assistant message (an action
+		result, for example) plus the user message of this turn. A conversation
+		without stored state — one from before the checkpointer, or one whose
+		checkpoints were cleared — is seeded once with its full stored history.
 		"""
 		history = self.runtime.conversation_history or []
+		if self.checkpointer.get_tuple(self.thread_config) is not None:
+			history = _history_after_last_assistant_message(history)
+
 		messages: list[AnyMessage] = []
 		for item in history:
 			native = history_item_to_native_message(item)
@@ -328,7 +343,12 @@ Mode awareness and behavior:
 	def run(self, message: str, conversation_history: list[dict[str, Any]]) -> dict[str, Any]:
 		self.runtime.conversation_history = conversation_history or []
 		input_messages = self._build_input_messages(message)
-		result = self.agent.invoke({"messages": input_messages})
+		result = self.agent.invoke({"messages": input_messages}, config=self.thread_config)
+		# LangGraph checkpoints from its background threads, which must not use
+		# this request's database connection. Nothing is stored until we flush
+		# here — and a failed run flushes nothing, so the conversation keeps the
+		# state of its last completed turn.
+		self.checkpointer.flush()
 		result_messages = result.get("messages") if isinstance(result, dict) else None
 		response_text = result_messages[-1].text.strip() if result_messages else ""
 
@@ -338,6 +358,21 @@ Mode awareness and behavior:
 			"document_extractions": self.runtime.document_extractions,
 			"attached_files": self.runtime.attached_files,
 		}
+
+
+def _history_after_last_assistant_message(
+	history: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+	"""Return the stored items the agent cannot have seen yet.
+
+	Everything up to and including the last assistant message is already in the
+	checkpointed thread. What follows it was appended by the app afterwards.
+	"""
+	for index in range(len(history) - 1, -1, -1):
+		if (history[index].get("role") or "").lower() == "assistant":
+			return history[index + 1 :]
+
+	return history
 
 
 def run_message(

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -12,10 +12,12 @@ from deepagents import (
 )
 from frappe import _
 from langchain.agents import create_agent
-from langchain.agents.middleware import ToolErrorMiddleware
+from langchain.agents.middleware import AgentMiddleware, ToolErrorMiddleware
 from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import AnyMessage, HumanMessage
 from langchain_openai import ChatOpenAI
+from langgraph.errors import GraphBubbleUp
+from langgraph.types import Command
 
 from ask_alyf.ask_alyf import tools
 from ask_alyf.ask_alyf.checkpointer import FrappeCheckpointSaver
@@ -29,6 +31,7 @@ from ask_alyf.ask_alyf.subagents import (
 	SourceCodeAnalysisResult,
 )
 from ask_alyf.ask_alyf.toolset import (
+	OPERATION_INTERRUPT_KEY,
 	ask_alyfRuntime,
 	ask_alyfToolset,
 	clear_messages_on_tool_error,
@@ -54,6 +57,143 @@ def _on_tool_error(exc: Exception, request: ToolCallRequest) -> str:
 def build_tool_error_middleware() -> ToolErrorMiddleware:
 	"""Build middleware that returns tool failures to the model for retry."""
 	return ToolErrorMiddleware(on_error=_on_tool_error)
+
+
+# Tool arguments are shown to the user, so a large payload (a full document,
+# an extracted PDF) is trimmed to keep the conversation record readable.
+TOOL_CALL_ARGS_LIMIT = 500
+
+
+def _summarize_tool_args(args: Any) -> dict[str, Any]:
+	"""Trim tool arguments down to something worth showing in the chat."""
+	if not isinstance(args, dict):
+		return {}
+
+	summary = {}
+	for key, value in args.items():
+		text = value if isinstance(value, str) else frappe.as_json(value, indent=None)
+		if len(text) > TOOL_CALL_ARGS_LIMIT:
+			text = text[:TOOL_CALL_ARGS_LIMIT] + "…"
+		summary[key] = text
+	return summary
+
+
+def _tool_call_label(name: str, args: Any) -> str:
+	"""Describe a tool call in the user's words, for the step list in the chat.
+
+	Names the record being worked on wherever the arguments carry one, because
+	"Reading Sales Invoice list" tells the user something that `get_list` does
+	not. Anything unmapped falls back to a readable form of the tool name, so a
+	new tool shows up in the list instead of disappearing from it.
+	"""
+	args = args if isinstance(args, dict) else {}
+	doctype = _(args["doctype"]) if isinstance(args.get("doctype"), str) else ""
+	docname = args["name"] if isinstance(args.get("name"), str) else ""
+	target = " ".join(part for part in (doctype, docname) if part)
+
+	if name == "get_list":
+		return _("Reading {0} list").format(doctype)
+	if name == "get_count":
+		return _("Counting {0}").format(doctype)
+	if name in ("get", "get_value", "get_single_value", "get_print"):
+		return _("Reading {0}").format(target or doctype)
+	if name == "get_meta":
+		return _("Checking the {0} form").format(doctype)
+	if name in ("has_permission", "get_doc_permissions"):
+		return _("Checking your permissions on {0}").format(doctype)
+	if name == "list_accessible_doctypes":
+		return _("Looking up what you can access")
+	if name == "list_accessible_reports":
+		return _("Looking up available reports")
+	if name == "translate_ui_labels":
+		return _("Translating labels")
+	if name == "run_read_only_sql":
+		return _("Running a database query")
+	if name in ("read_skill", "write_skill"):
+		return _("Reading instructions") if name == "read_skill" else _("Saving instructions")
+	if name in ("get_file_id", "read_file_record", "extract_document_data"):
+		return _("Reading the attached document")
+	if name in ("get_app_version", "read_github_releases", "read_documentation_page"):
+		return _("Reading documentation")
+	if name in ("ls", "read_file", "glob", "grep"):
+		return _("Searching the source code")
+	if name == "task":
+		return _("Asking the {0} specialist").format(args.get("subagent_type") or _("assistant"))
+	if name == "write_todos":
+		return _("Planning the next steps")
+
+	if name == "insert":
+		return _("Creating {0}").format(doctype)
+	if name == "batch_insert":
+		return _("Creating several {0} records").format(doctype)
+	if name in ("save", "set_value"):
+		return _("Updating {0}").format(target or doctype)
+	if name == "submit":
+		return _("Submitting {0}").format(target or doctype)
+	if name == "cancel":
+		return _("Cancelling {0}").format(target or doctype)
+	if name == "amend":
+		return _("Amending {0}").format(target or doctype)
+	if name == "delete":
+		return _("Deleting {0}").format(target or doctype)
+	if name == "rename_doc":
+		return _("Renaming {0}").format(target or doctype)
+	if name == "attach_file":
+		return _("Attaching a file to {0}").format(target or doctype)
+	if name == "run_whitelisted_method":
+		return _("Running {0}").format(args.get("method") or _("an action"))
+
+	if name == "set_route":
+		return _("Opening a page")
+	if name == "new_doc":
+		return _("Opening a new {0}").format(doctype)
+	if name == "scroll_to_field":
+		return _("Highlighting a field")
+	if name == "show_chart":
+		return _("Preparing a chart")
+	if name in ("frm_set_value", "frm_add_child"):
+		return _("Filling in the open form")
+
+	return name.replace("_", " ").capitalize()
+
+
+class ToolCallLogMiddleware(AgentMiddleware):
+	"""Show the user each tool call as it happens, and keep the list afterwards.
+
+	Every call is announced when it starts and updated when it ends, so the
+	chat builds up a live list of steps instead of a single status line that
+	overwrites itself. The same list is persisted with the assistant message,
+	so reopening the conversation still shows what the agent did.
+	"""
+
+	def __init__(self, runtime: ask_alyfRuntime):
+		super().__init__()
+		self.runtime = runtime
+
+	def wrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Any]) -> Any:
+		call = request.tool_call
+		call_id = call.get("id") or ""
+		self.runtime.begin_tool_call(
+			call_id,
+			call.get("name") or "",
+			_summarize_tool_args(call.get("args")),
+			_tool_call_label(call.get("name") or "", call.get("args")),
+		)
+		try:
+			result = handler(request)
+		except GraphBubbleUp:
+			# A paused proposal has not happened yet: drop it from the list
+			# until the user decides and the tool node runs again.
+			self.runtime.drop_tool_call(call_id)
+			raise
+		except Exception:
+			self.runtime.finish_tool_call(call_id, "failed")
+			raise
+
+		self.runtime.finish_tool_call(
+			call_id, "failed" if getattr(result, "status", None) == "error" else "success"
+		)
+		return result
 
 
 # Deep Agents exposes built-in filesystem write tools (``write_file``,
@@ -134,7 +274,7 @@ class ask_alyfAgentRunner:
 			backend=self.backend,
 			subagents=self._build_subagents(),
 			permissions=self._build_permissions(),
-			middleware=[build_tool_error_middleware()],
+			middleware=[build_tool_error_middleware(), ToolCallLogMiddleware(runtime)],
 			checkpointer=self.checkpointer,
 			name="ask_alyf",
 		)
@@ -187,7 +327,8 @@ Always follow these rules:
 Mode awareness and behavior:
 - The current mode is `{self.runtime.mode}` and is authoritative for this turn.
 - `Ask` mode is strictly read-only: write tools are unavailable, so if intent is mutation (create, update, submit, cancel, amend, rename, delete, attach, or a write method), immediately recommend switching to `Agent` mode and do not claim anything was done or queued.
-- `Agent` mode supports mutation workflows with write tools while still handling read-only questions with read tools. Every write tool call creates a pending proposal that requires user confirmation before execution. Multiple proposals can be created in a single turn — if the request needs several writes, propose them all now. The user will confirm or reject each one individually.
+- `Agent` mode supports mutation workflows with write tools while still handling read-only questions with read tools. A write tool call pauses and waits for the user to confirm; the tool then returns the real outcome to you, so you learn whether it succeeded before deciding what to do next.
+- Call one write tool at a time and wait for its result. If a request needs several writes, do the first, read its result, then do the next. Never propose two write tools in the same step.
 - Frontend action tools can navigate or adjust the current form in the browser, or display Frappe Charts under the assistant message via `show_chart` (pass `frappe_charts` as a list of chart option objects; validated server-side). See the `show_chart` tool docstring for the options shape.
 - Frontend actions with `requires_confirmation` must be confirmed before the browser executes them.
 - In `Agent` mode, prefer the `document-planner` subagent (via the `task` tool) before non-trivial `insert`, `save`, or `set_value` operations. If it returns `ready=false`, ask the user for the missing information instead of guessing. If it returns `ready=true`, use the matching write tool with the returned payload.
@@ -196,7 +337,8 @@ Mode awareness and behavior:
 - Child table fields (fieldtype Table) must be arrays of row objects, never plain strings.
 - Act on clear intent immediately with sensible defaults. Only ask when required information is truly missing and cannot be inferred.
 - Never repeat the user's data in your response. The UI shows a detailed preview of every pending write. After calling a write tool, confirm readiness in one sentence.
-- When you receive an action result (success, failure, or rejection), confirm the outcome briefly. If a natural follow-up action exists (e.g. submitting a newly created document), proceed with it. Do not ask "would you like me to..." — just do it.
+- A write tool that returns `rejected` means the user declined it. Acknowledge briefly, suggest an alternative if there is one, and never retry the same operation.
+- When a write tool returns a result, confirm the outcome briefly. If a natural follow-up action exists (e.g. submitting a newly created document), proceed with it. Do not ask "would you like me to..." — just do it.
 - Excluded DocTypes for Agent mode: {excluded_doctypes}
 """.strip()
 
@@ -310,7 +452,7 @@ Mode awareness and behavior:
 							self.toolset.list_accessible_doctypes,
 						)
 					],
-					"middleware": [build_tool_error_middleware()],
+					"middleware": [build_tool_error_middleware(), ToolCallLogMiddleware(self.runtime)],
 					"response_format": DocumentPlannerResult,
 				}
 			)
@@ -343,7 +485,26 @@ Mode awareness and behavior:
 	def run(self, message: str, conversation_history: list[dict[str, Any]]) -> dict[str, Any]:
 		self.runtime.conversation_history = conversation_history or []
 		input_messages = self._build_input_messages(message)
-		result = self.agent.invoke({"messages": input_messages}, config=self.thread_config)
+
+		# A proposal the user never answered still holds the graph. Sending a
+		# new message means they moved on, so the proposal counts as rejected
+		# and the new message rides along with the same resume.
+		abandoned = self._pending_operation_call_id()
+		if abandoned:
+			command = Command(
+				resume={"call_id": abandoned, "status": "rejected"},
+				update={"messages": input_messages},
+			)
+			return self._finish(self.agent.invoke(command, config=self.thread_config))
+
+		return self._finish(self.agent.invoke({"messages": input_messages}, config=self.thread_config))
+
+	def resume(self, call_id: str, status: str, **decision: Any) -> dict[str, Any]:
+		"""Continue a run that paused on a proposal, with the user's decision."""
+		command = Command(resume={"call_id": call_id, "status": status, **decision})
+		return self._finish(self.agent.invoke(command, config=self.thread_config))
+
+	def _finish(self, result: Any) -> dict[str, Any]:
 		# LangGraph checkpoints from its background threads, which must not use
 		# this request's database connection. Nothing is stored until we flush
 		# here — and a failed run flushes nothing, so the conversation keeps the
@@ -354,10 +515,30 @@ Mode awareness and behavior:
 
 		return {
 			"response": response_text,
-			"pending_operations": self.runtime.pending_operations,
+			"pending_operations": [*self.runtime.pending_operations, *_interrupted_operations(result)],
 			"document_extractions": self.runtime.document_extractions,
 			"attached_files": self.runtime.attached_files,
+			"tool_calls": self.runtime.tool_calls,
 		}
+
+	def _pending_operation_call_id(self) -> str:
+		"""Return the call_id of the proposal this thread is paused on, if any."""
+		state = self.agent.get_state(self.thread_config)
+		for operation in _interrupted_operations({"__interrupt__": state.interrupts}):
+			return operation.get("call_id") or ""
+		return ""
+
+
+def _interrupted_operations(result: Any) -> list[dict[str, Any]]:
+	"""Read the operations a paused graph is waiting on out of its interrupts."""
+	operations = []
+	for item in (result.get("__interrupt__") if isinstance(result, dict) else None) or ():
+		value = getattr(item, "value", item)
+		operation = value.get(OPERATION_INTERRUPT_KEY) if isinstance(value, dict) else None
+		if isinstance(operation, dict):
+			operations.append(operation)
+
+	return operations
 
 
 def _history_after_last_assistant_message(
@@ -390,6 +571,30 @@ def run_message(
 	)
 	runner = ask_alyfAgentRunner(runtime)
 	return runner.run(message, conversation_history)
+
+
+def resume_operation(
+	conversation_name: str,
+	mode: str,
+	request_context: dict[str, Any],
+	*,
+	call_id: str,
+	status: str,
+	**decision: Any,
+) -> dict[str, Any]:
+	"""Continue the paused run of a conversation with the user's decision.
+
+	The agent is holding inside the tool that proposed the operation, so the
+	decision reaches it as that tool's own result — there is no need to
+	replay the conversation or describe the outcome back to the model.
+	"""
+	runtime = ask_alyfRuntime(
+		conversation_name=conversation_name,
+		mode=mode,
+		request_context=request_context,
+	)
+	runner = ask_alyfAgentRunner(runtime)
+	return runner.resume(call_id, status, **decision)
 
 
 # ``create_agent`` is re-exported so the field agent (and any future stateless

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -426,8 +426,7 @@ def send_message(
 	# race on `messages_json`, so a conversation gets one run at a time. The row
 	# lock closes the window between the check and the enqueue; it is released
 	# on commit, which is also when the job is handed to the queue.
-	frappe.db.get_value("Ask ALYF Conversation", doc.name, "name", for_update=True)
-	doc.reload()
+	doc = frappe.get_doc("Ask ALYF Conversation", doc.name, for_update=True)
 
 	messages = get_messages(doc)
 	if _has_running_job(messages):
@@ -638,7 +637,11 @@ def confirm_pending_operation(conversation: str, call_id: str = "", mode: str = 
 	if not can_access_ask_alyf():
 		frappe.throw(_("You do not have access to Ask ALYF."))
 
-	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	# Locked: the removal below is only persisted once the resumed run returns,
+	# so two overlapping requests would both see the operation as pending and
+	# both resume the same checkpoint, executing the write twice. The second
+	# request waits here and then finds the operation already gone.
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation, for_update=True)
 	doc.check_permission("write")
 	all_operations = load_pending_operations(doc.pending_operation_json)
 	if not all_operations:
@@ -699,7 +702,7 @@ def reject_pending_operation(conversation: str, call_id: str = "", mode: str = M
 	if not can_access_ask_alyf():
 		frappe.throw(_("You do not have access to Ask ALYF."))
 
-	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation, for_update=True)
 	doc.check_permission("write")
 	all_operations = load_pending_operations(doc.pending_operation_json)
 	if not all_operations:
@@ -804,7 +807,7 @@ def frontend_action_result(
 	if not can_access_ask_alyf():
 		frappe.throw(_("You do not have access to Ask ALYF."))
 
-	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation, for_update=True)
 	doc.check_permission("write")
 	all_operations = load_pending_operations(doc.pending_operation_json)
 	if not all_operations:

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -26,6 +26,15 @@ MODE_ASK = "Ask"
 MODE_AGENT = "Agent"
 ASK_ALYF_USER_ROLE = "Ask ALYF User"
 BACKGROUND_JOB_ID_KEY = "background_job_id"
+PENDING_JOB_STATUSES = frozenset(
+	{
+		JobStatus.CREATED,
+		JobStatus.QUEUED,
+		JobStatus.STARTED,
+		JobStatus.DEFERRED,
+		JobStatus.SCHEDULED,
+	}
+)
 
 
 def _truncate_doc_for_size(
@@ -384,6 +393,21 @@ def start_new_conversation() -> dict:
 	return conversation_payload(doc)
 
 
+def _has_running_job(messages: list[dict]) -> bool:
+	"""Is a background run for this conversation still in flight?
+
+	Walks back to the newest user message that was enqueued. An assistant reply
+	after it means that run already landed.
+	"""
+	for item in reversed(messages):
+		if item.get("role") == "assistant":
+			return False
+		job_id = (item.get("metadata") or {}).get(BACKGROUND_JOB_ID_KEY)
+		if job_id:
+			return get_job_status(job_id) in PENDING_JOB_STATUSES
+	return False
+
+
 @frappe.whitelist(methods=["POST"])
 def send_message(
 	message: str,
@@ -398,7 +422,17 @@ def send_message(
 	context_data = frappe.parse_json(context) if isinstance(context, str) else (context or {})
 	doc = get_or_create_conversation(conversation_name=conversation)
 
+	# Two runs on one conversation would fork the agent's stored graph state and
+	# race on `messages_json`, so a conversation gets one run at a time. The row
+	# lock closes the window between the check and the enqueue; it is released
+	# on commit, which is also when the job is handed to the queue.
+	frappe.db.get_value("Ask ALYF Conversation", doc.name, "name", for_update=True)
+	doc.reload()
+
 	messages = get_messages(doc)
+	if _has_running_job(messages):
+		frappe.throw(_("Ask ALYF is still working on the previous message in this conversation."))
+
 	job_id = uuid4().hex
 	user_message = make_message(
 		"user",
@@ -462,13 +496,7 @@ def get_message_job_status(conversation: str, user_message_id: str, job_id: str)
 		return {"status": "completed", "conversation": conversation_payload(doc)}
 
 	status = get_job_status(job_id)
-	if status in {
-		JobStatus.CREATED,
-		JobStatus.QUEUED,
-		JobStatus.STARTED,
-		JobStatus.DEFERRED,
-		JobStatus.SCHEDULED,
-	}:
+	if status in PENDING_JOB_STATUSES:
 		# Steps broadcast while the user was elsewhere cannot be replayed, so
 		# the run's progress so far rides along with the status.
 		return {"status": "pending", "tool_calls": read_running_steps(conversation)}

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -12,11 +12,10 @@ from frappe.utils.data import cint
 from rq.job import JobStatus
 
 from ask_alyf.ask_alyf import field_agent
-from ask_alyf.ask_alyf.agent import run_message
+from ask_alyf.ask_alyf.agent import resume_operation, run_message
 from ask_alyf.ask_alyf.tools import (
 	OPERATION_KIND_BACKEND,
 	OPERATION_KIND_FRONTEND,
-	execute_pending_operation,
 	get_settings,
 	validate_frappe_charts_payload,
 )
@@ -161,6 +160,7 @@ def build_assistant_message_metadata(
 	*,
 	pending_operations: list[dict[str, Any]] | None = None,
 	document_extractions: list[dict[str, Any]] | None = None,
+	tool_calls: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
 	"""Build persisted metadata for an assistant message."""
 	metadata = {
@@ -169,6 +169,8 @@ def build_assistant_message_metadata(
 	}
 	if isinstance(document_extractions, list) and document_extractions:
 		metadata["document_extractions"] = document_extractions
+	if isinstance(tool_calls, list) and tool_calls:
+		metadata["tool_calls"] = tool_calls
 	return metadata
 
 
@@ -201,6 +203,7 @@ def apply_agent_result_to_conversation(
 			mode,
 			pending_operations=new_operations,
 			document_extractions=document_extractions,
+			tool_calls=result.get("tool_calls"),
 		),
 		**extra_metadata,
 	)
@@ -288,114 +291,27 @@ def save_messages(conversation, messages: list[dict]):
 	conversation.save()
 
 
-def _build_confirm_ack_content(
-	pending_operation: dict[str, Any],
-	action_result: dict[str, Any],
-	execution_error: str | None,
-) -> str:
-	if execution_error:
-		return _("Could not confirm operation: {0}").format(execution_error)
-
-	content = _("Confirmed operation: {0}").format(
-		pending_operation.get("summary") or pending_operation.get("tool")
-	)
-	if action_result.get("doctype") and action_result.get("name"):
-		content += "\n\n" + _("Document: {0} {1}").format(
-			_(action_result["doctype"]),
-			action_result["name"],
-		)
-	elif action_result.get("message"):
-		content += "\n\n" + str(action_result["message"])
-	return content
-
-
-def _collect_completed_action_summaries(messages: list[dict[str, Any]]) -> list[str]:
-	"""Collect one-line summaries of successfully executed or rejected actions.
-
-	Failed actions are intentionally excluded so the agent may retry them.
-	"""
-	summaries = []
-	for msg in messages:
-		if msg.get("role") != "assistant":
-			continue
-		meta = msg.get("metadata") or {}
-		content = (msg.get("content") or "").split("\n", 1)[0].strip()
-		status = meta.get("action_status") or meta.get("frontend_action_status")
-		if meta.get("rejected_action") or status == "rejected":
-			summaries.append(f"- Rejected by user: {content}")
-		elif status == "success":
-			summaries.append(f"- Executed successfully: {content}")
-	return summaries
-
-
-def continue_after_action(
+def resume_pending_operation(
 	conversation,
 	mode: str,
-	messages: list[dict[str, Any]],
 	pending_operation: dict[str, Any],
 	*,
 	status: str,
-	result_payload: dict[str, Any] | None = None,
-	error: str | None = None,
+	**decision: Any,
 ) -> dict[str, Any] | None:
-	"""Run the agent after an action result so it can confirm, handle errors, or propose follow-ups."""
+	"""Hand the user's decision to the agent, which is paused inside the tool."""
 	request_context = loads(conversation.last_context_json, {})
 	if not isinstance(request_context, dict):
 		request_context = {}
 
-	operation_payload = pending_operation.get("payload")
-	operation_payload = operation_payload if isinstance(operation_payload, dict) else {}
-	system_payload: dict[str, Any] = {
-		"status": status,
-		"operation": {
-			"kind": pending_operation.get("kind"),
-			"tool": pending_operation.get("tool"),
-			"summary": pending_operation.get("summary"),
-			"payload": operation_payload,
-		},
-	}
-	if result_payload:
-		system_payload["result"] = result_payload
-	if error:
-		system_payload["error"] = error
-
-	if status == "rejected":
-		system_message = (
-			"The user rejected this proposed action. "
-			"Acknowledge briefly. If you can suggest an alternative, do so.\n"
-			f"{dumps(system_payload)}"
-		)
-	else:
-		system_message = (
-			"This action has been executed. "
-			"Use the result context below to continue.\n"
-			f"{dumps(system_payload)}"
-		)
-
-	prior_actions = _collect_completed_action_summaries(messages)
-	if prior_actions:
-		system_message += (
-			"\n\nActions already completed earlier in this conversation:\n"
-			+ "\n".join(prior_actions)
-			+ "\n\nDo NOT re-propose any action that was already executed or rejected."
-		)
-
-	history_with_result = list(messages)
-	history_with_result.append({"role": "system", "content": system_message})
-
 	try:
-		return run_message(
+		return resume_operation(
 			conversation_name=conversation.name,
-			message=(
-				"Confirm the action result briefly. "
-				"If the user's original request is not fully completed, "
-				"proceed with the next write action now. "
-				"NEVER re-propose an action that was already executed or confirmed. "
-				"If all requested changes are done, summarize the results and stop."
-			),
 			mode=mode,
 			request_context=request_context,
-			conversation_history=history_with_result,
+			call_id=pending_operation.get("call_id") or "",
+			status=status,
+			**decision,
 		)
 	except Exception:
 		frappe.log_error("Ask ALYF Action Follow-Up Error")
@@ -606,6 +522,7 @@ def process_message_job(
 			pending_operations = []
 		document_extractions = result.get("document_extractions")
 		attached_files = result.get("attached_files")
+		tool_calls = result.get("tool_calls")
 		if pending_operations and not response:
 			response = _("I've prepared the operation. Please review and confirm.")
 	except frappe.ValidationError as exc:
@@ -614,6 +531,7 @@ def process_message_job(
 		pending_operations = []
 		document_extractions = None
 		attached_files = None
+		tool_calls = None
 	except Exception:
 		frappe.log_error("Ask ALYF Agent Error")
 		frappe.clear_messages()
@@ -621,6 +539,7 @@ def process_message_job(
 		pending_operations = []
 		document_extractions = None
 		attached_files = None
+		tool_calls = None
 
 	file_message = None
 	if isinstance(attached_files, list) and attached_files:
@@ -635,6 +554,7 @@ def process_message_job(
 			mode,
 			pending_operations=pending_operations,
 			document_extractions=document_extractions,
+			tool_calls=tool_calls,
 		),
 	)
 	messages.append(assistant_message)
@@ -670,6 +590,9 @@ def process_message_job(
 			"conversation": conversation_name,
 			"message_id": assistant_message["id"],
 			"pending_operations": stamped,
+			# The streamed message is assembled from chunks and carries no
+			# metadata of its own, so the steps travel with the completion.
+			"tool_calls": assistant_message["metadata"].get("tool_calls") or [],
 		},
 		user=doc.owner,
 	)
@@ -699,67 +622,39 @@ def confirm_pending_operation(conversation: str, call_id: str = "", mode: str = 
 
 	publish_status_update(doc.name, doc.owner, _("Confirming action..."))
 	try:
-		execution_error = None
-		try:
-			result = execute_pending_operation(pending_operation)
-		except Exception as error:
-			frappe.log_error("Ask ALYF Confirm Action Error")
-			frappe.clear_messages()
-			execution_error = str(error)
-			result = None
+		# The agent is paused inside the tool that proposed this operation and
+		# executes it itself on resume, so the outcome reaches the model as
+		# that tool's own result.
+		agent_result = resume_pending_operation(
+			doc,
+			normalized_mode,
+			pending_operation,
+			status="approved",
+		)
+		ack_meta = {"confirmed_action": True, "action_status": "success" if agent_result else "failed"}
 
-		operation_payload = pending_operation.get("payload") if isinstance(pending_operation, dict) else {}
-		operation_payload = operation_payload if isinstance(operation_payload, dict) else {}
-		action_result = {
-			"kind": pending_operation.get("kind"),
-			"tool": pending_operation.get("tool"),
-			"summary": pending_operation.get("summary"),
-			"doctype": operation_payload.get("doctype"),
-			"name": operation_payload.get("name"),
-		}
-		if isinstance(result, dict):
-			action_result["name"] = result.get("name") or result.get("new_name") or action_result["name"]
-			action_result["message"] = result.get("message")
-		action_result = {key: value for key, value in action_result.items() if value not in (None, "")}
-
-		status = "failed" if execution_error else "success"
-
-		ack_meta = {"confirmed_action": True, "action_status": status}
-
-		if remaining:
-			content = _build_confirm_ack_content(pending_operation, action_result, execution_error)
-			messages.append(make_message("assistant", content, mode=normalized_mode, **ack_meta))
-			save_messages(doc, messages)
-		else:
-			publish_status_update(doc.name, doc.owner, _("Generating response..."))
-			agent_result = continue_after_action(
+		if agent_result:
+			apply_agent_result_to_conversation(
 				doc,
-				normalized_mode,
 				messages,
-				pending_operation,
-				status=status,
-				result_payload=action_result,
-				error=execution_error,
+				agent_result,
+				normalized_mode,
+				**ack_meta,
 			)
-			if agent_result:
-				apply_agent_result_to_conversation(
-					doc,
-					messages,
-					agent_result,
-					normalized_mode,
-					**ack_meta,
-				)
-			else:
-				content = _build_confirm_ack_content(pending_operation, action_result, execution_error)
-				messages.append(make_message("assistant", content, mode=normalized_mode, **ack_meta))
-				save_messages(doc, messages)
+			return {"conversation": conversation_payload(doc)}
 
-		response_payload: dict[str, Any] = {"conversation": conversation_payload(doc)}
-		if execution_error:
-			response_payload["error"] = execution_error
-		else:
-			response_payload["result"] = action_result
-		return response_payload
+		messages.append(
+			make_message(
+				"assistant",
+				_("Could not complete the operation: {0}.").format(
+					pending_operation.get("summary") or pending_operation.get("tool")
+				),
+				mode=normalized_mode,
+				**ack_meta,
+			)
+		)
+		save_messages(doc, messages)
+		return {"conversation": conversation_payload(doc)}
 	finally:
 		publish_status_update(doc.name, doc.owner, "")
 
@@ -784,46 +679,34 @@ def reject_pending_operation(conversation: str, call_id: str = "", mode: str = M
 	normalized_mode = normalize_mode(mode)
 	messages = get_messages(doc)
 
+	publish_status_update(doc.name, doc.owner, _("Generating response..."))
 	try:
-		summary = pending_operation.get("summary") or pending_operation.get("tool")
-
-		if remaining:
+		agent_result = resume_pending_operation(
+			doc,
+			normalized_mode,
+			pending_operation,
+			status="rejected",
+		)
+		if agent_result:
+			apply_agent_result_to_conversation(
+				doc,
+				messages,
+				agent_result,
+				normalized_mode,
+				rejected_action=True,
+			)
+		else:
 			messages.append(
 				make_message(
 					"assistant",
-					_("Cancelled the pending operation: {0}.").format(summary),
+					_("Cancelled the pending operation: {0}.").format(
+						pending_operation.get("summary") or pending_operation.get("tool")
+					),
 					rejected_action=True,
 					mode=normalized_mode,
 				)
 			)
 			save_messages(doc, messages)
-		else:
-			publish_status_update(doc.name, doc.owner, _("Generating response..."))
-			agent_result = continue_after_action(
-				doc,
-				normalized_mode,
-				messages,
-				pending_operation,
-				status="rejected",
-			)
-			if agent_result:
-				apply_agent_result_to_conversation(
-					doc,
-					messages,
-					agent_result,
-					normalized_mode,
-					rejected_action=True,
-				)
-			else:
-				messages.append(
-					make_message(
-						"assistant",
-						_("Cancelled the pending operation: {0}.").format(summary),
-						rejected_action=True,
-						mode=normalized_mode,
-					)
-				)
-				save_messages(doc, messages)
 
 		return {"conversation": conversation_payload(doc)}
 	finally:
@@ -937,7 +820,28 @@ def frontend_action_result(
 
 		summary = pending_operation.get("summary") or pending_operation.get("tool") or _("frontend action")
 
-		if remaining:
+		# An auto-executed action never paused the graph, so there is nothing
+		# to resume — the browser result is only recorded for the user.
+		agent_result = None
+		if pending_operation.get("requires_confirmation"):
+			agent_result = resume_pending_operation(
+				doc,
+				normalized_mode,
+				pending_operation,
+				status=status_value,
+				result=result_payload,
+				error=error,
+			)
+
+		if agent_result:
+			apply_agent_result_to_conversation(
+				doc,
+				messages,
+				agent_result,
+				normalized_mode,
+				**extra_metadata,
+			)
+		else:
 			if status_value == "success":
 				content = _("Executed frontend action: {0}").format(summary)
 			elif status_value == "rejected":
@@ -948,35 +852,6 @@ def frontend_action_result(
 					content += "\n\n" + _("Reason: {0}").format(error)
 			messages.append(make_message("assistant", content, mode=normalized_mode, **extra_metadata))
 			save_messages(doc, messages)
-		else:
-			agent_result = continue_after_action(
-				doc,
-				normalized_mode,
-				messages,
-				pending_operation,
-				status=status_value,
-				result_payload=result_payload,
-				error=error,
-			)
-			if agent_result:
-				apply_agent_result_to_conversation(
-					doc,
-					messages,
-					agent_result,
-					normalized_mode,
-					**extra_metadata,
-				)
-			else:
-				if status_value == "success":
-					content = _("Executed frontend action: {0}").format(summary)
-				elif status_value == "rejected":
-					content = _("Cancelled frontend action: {0}").format(summary)
-				else:
-					content = _("Frontend action failed: {0}").format(summary)
-					if error:
-						content += "\n\n" + _("Reason: {0}").format(error)
-				messages.append(make_message("assistant", content, mode=normalized_mode, **extra_metadata))
-				save_messages(doc, messages)
 
 		return {"conversation": conversation_payload(doc)}
 	finally:

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -19,6 +19,7 @@ from ask_alyf.ask_alyf.tools import (
 	get_settings,
 	validate_frappe_charts_payload,
 )
+from ask_alyf.ask_alyf.toolset import clear_running_steps, read_running_steps
 from ask_alyf.ask_alyf.utils import chunk_text, dumps, loads
 
 MODE_ASK = "Ask"
@@ -468,7 +469,9 @@ def get_message_job_status(conversation: str, user_message_id: str, job_id: str)
 		JobStatus.DEFERRED,
 		JobStatus.SCHEDULED,
 	}:
-		return {"status": "pending"}
+		# Steps broadcast while the user was elsewhere cannot be replayed, so
+		# the run's progress so far rides along with the status.
+		return {"status": "pending", "tool_calls": read_running_steps(conversation)}
 	if status in {JobStatus.FINISHED, JobStatus.FAILED, JobStatus.STOPPED, JobStatus.CANCELED}:
 		doc.reload()
 		messages = get_messages(doc)
@@ -502,6 +505,7 @@ def process_message_job(
 	messages = get_messages(doc)
 	history = messages[:-1] if messages and messages[-1].get("id") == user_message_id else messages
 
+	clear_running_steps(conversation_name)
 	frappe.publish_realtime(
 		"ask_alyf_response_start",
 		{"conversation": conversation_name},
@@ -572,6 +576,9 @@ def process_message_job(
 			},
 			user=doc.owner,
 		)
+
+	# The steps live on the assistant message now.
+	clear_running_steps(conversation_name)
 
 	for chunk in chunk_text(response or " "):
 		frappe.publish_realtime(

--- a/ask_alyf/ask_alyf/checkpointer.py
+++ b/ask_alyf/ask_alyf/checkpointer.py
@@ -348,9 +348,12 @@ class FrappeCheckpointSaver(BaseCheckpointSaver[int]):
 		]
 
 	def _upsert(self, doctype: str, name: str, values: dict[str, Any]) -> None:
-		# ponytail: check-then-insert, not an atomic upsert. Two workers writing
-		# the same checkpoint row would need INSERT ... ON DUPLICATE KEY; one
-		# conversation is handled by one worker, so this is enough.
+		# ponytail: check-then-insert, not an atomic upsert. Safe because a
+		# conversation only ever has one run in flight — `send_message` takes a
+		# row lock on the conversation and refuses to enqueue a second job while
+		# one is pending. Concurrent runs would fork the thread's stored state
+		# long before they collided on a row, so that guard is the fix, not
+		# INSERT ... ON DUPLICATE KEY here.
 		if frappe.db.exists(doctype, name):
 			frappe.db.set_value(doctype, name, values, update_modified=False)
 			return

--- a/ask_alyf/ask_alyf/checkpointer.py
+++ b/ask_alyf/ask_alyf/checkpointer.py
@@ -65,6 +65,15 @@ def _row_name(*parts: Any) -> str:
 	return hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()
 
 
+def delete_checkpoints(thread_ids: Sequence[str]) -> None:
+	"""Delete every checkpoint and pending write of the given threads."""
+	if not thread_ids:
+		return
+
+	for doctype in (CHECKPOINT_DOCTYPE, CHECKPOINT_WRITE_DOCTYPE):
+		frappe.db.delete(doctype, {"thread_id": ("in", tuple(thread_ids))})
+
+
 def checkpoint_row_name(thread_id: str, checkpoint_ns: str | None, checkpoint_id: str) -> str:
 	"""Name of the `Ask ALYF Checkpoint` row for one checkpoint."""
 	return _row_name(thread_id, checkpoint_ns or "", checkpoint_id)
@@ -272,8 +281,7 @@ class FrappeCheckpointSaver(BaseCheckpointSaver[int]):
 			for key in [key for key, values in self._buffer.items() if values["thread_id"] == thread_id]:
 				del self._buffer[key]
 
-		frappe.db.delete(CHECKPOINT_DOCTYPE, {"thread_id": thread_id})
-		frappe.db.delete(CHECKPOINT_WRITE_DOCTYPE, {"thread_id": thread_id})
+		delete_checkpoints([thread_id])
 
 	# --- internals ----------------------------------------------------------
 

--- a/ask_alyf/ask_alyf/checkpointer.py
+++ b/ask_alyf/ask_alyf/checkpointer.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2026, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+"""LangGraph checkpointer backed by the Frappe ORM.
+
+Stores checkpoints in `Ask ALYF Checkpoint` and pending writes in
+`Ask ALYF Checkpoint Write`, so an agent thread survives across requests
+without a second datastore. The `thread_id` of the graph config is expected to
+be the `Ask ALYF Conversation` name.
+
+Three properties worth knowing:
+
+* LangGraph runs `put` and `put_writes` on its background executor, and a
+  Frappe database connection belongs to the thread (context) that opened it.
+  So writes are buffered in memory and persisted by `flush()`, which the
+  caller runs on its own thread once the graph run returns. Reads flush first,
+  so the database stays the single source of truth.
+* Writes ride the current Frappe transaction — nothing is committed here. If
+  the request rolls back, so do the checkpoints, which keeps stored state and
+  conversation documents consistent.
+* Sync only. Frappe's database connection is not usable from a different
+  thread or event loop, so the async `BaseCheckpointSaver` methods are
+  deliberately left unimplemented (they raise `NotImplementedError`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from base64 import b64decode, b64encode
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import frappe
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+	WRITES_IDX_MAP,
+	BaseCheckpointSaver,
+	ChannelVersions,
+	Checkpoint,
+	CheckpointMetadata,
+	CheckpointTuple,
+	PendingWrite,
+	get_checkpoint_id,
+	get_checkpoint_metadata,
+)
+
+CHECKPOINT_DOCTYPE = "Ask ALYF Checkpoint"
+CHECKPOINT_WRITE_DOCTYPE = "Ask ALYF Checkpoint Write"
+
+CHECKPOINT_FIELDS = (
+	"thread_id",
+	"checkpoint_ns",
+	"checkpoint_id",
+	"parent_checkpoint_id",
+	"checkpoint_type",
+	"checkpoint_data",
+	"metadata_type",
+	"metadata_data",
+)
+
+
+def _row_name(*parts: Any) -> str:
+	key = "\x00".join("" if part is None else str(part) for part in parts)
+	return hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()
+
+
+def checkpoint_row_name(thread_id: str, checkpoint_ns: str | None, checkpoint_id: str) -> str:
+	"""Name of the `Ask ALYF Checkpoint` row for one checkpoint."""
+	return _row_name(thread_id, checkpoint_ns or "", checkpoint_id)
+
+
+def checkpoint_write_row_name(
+	thread_id: str, checkpoint_ns: str | None, checkpoint_id: str, task_id: str, idx: int
+) -> str:
+	"""Name of the `Ask ALYF Checkpoint Write` row for one pending write."""
+	return _row_name(thread_id, checkpoint_ns or "", checkpoint_id, task_id, int(idx))
+
+
+class FrappeCheckpointSaver(BaseCheckpointSaver[int]):
+	"""Checkpointer that persists LangGraph state through the Frappe ORM.
+
+	Usage:
+
+	    saver = FrappeCheckpointSaver()
+	    agent = create_deep_agent(..., checkpointer=saver)
+	    try:
+	        agent.invoke(
+	            {"messages": [HumanMessage(content=message)]},
+	            config={"configurable": {"thread_id": conversation_name}},
+	        )
+	    finally:
+	        saver.flush()
+	"""
+
+	def __init__(self, *, serde=None) -> None:
+		super().__init__(serde=serde)
+		# Rows written by the graph, keyed by (doctype, name), in write order.
+		# Filled from LangGraph's background threads, drained by `flush()` on
+		# the thread that owns the Frappe database connection.
+		self._buffer: dict[tuple[str, str], dict[str, Any]] = {}
+		self._lock = threading.Lock()
+
+	# --- persisting ---------------------------------------------------------
+
+	def flush(self) -> None:
+		"""Write buffered checkpoints and writes to the database.
+
+		Call this on the thread that owns the Frappe connection (the request
+		thread) after a graph run. Reads call it too, so a checkpoint is never
+		served from a stale database.
+		"""
+		with self._lock:
+			buffered = list(self._buffer.items())
+			self._buffer.clear()
+
+		for (doctype, name), values in buffered:
+			# A regular write (non-negative index) is immutable once stored;
+			# only the special channels (`__resume__` and friends, which map to
+			# a negative index) may replace an existing row.
+			if doctype == CHECKPOINT_WRITE_DOCTYPE and values["idx"] >= 0:
+				if frappe.db.exists(doctype, name):
+					continue
+
+			self._upsert(doctype, name, values)
+
+	# --- reading ------------------------------------------------------------
+
+	def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+		self.flush()
+		thread_id = config["configurable"]["thread_id"]
+		checkpoint_ns = config["configurable"].get("checkpoint_ns", "") or ""
+		checkpoint_id = get_checkpoint_id(config)
+
+		if checkpoint_id:
+			row = frappe.db.get_value(
+				CHECKPOINT_DOCTYPE,
+				checkpoint_row_name(thread_id, checkpoint_ns, checkpoint_id),
+				CHECKPOINT_FIELDS,
+				as_dict=True,
+			)
+		else:
+			rows = frappe.db.get_all(
+				CHECKPOINT_DOCTYPE,
+				filters={"thread_id": thread_id, "checkpoint_ns": checkpoint_ns},
+				fields=CHECKPOINT_FIELDS,
+				order_by="checkpoint_id desc",
+				limit=1,
+			)
+			row = rows[0] if rows else None
+
+		return self._to_tuple(row) if row else None
+
+	def list(
+		self,
+		config: RunnableConfig | None,
+		*,
+		filter: dict[str, Any] | None = None,
+		before: RunnableConfig | None = None,
+		limit: int | None = None,
+	) -> Iterator[CheckpointTuple]:
+		self.flush()
+		filters: list[list[Any]] = []
+		if config:
+			filters.append(["thread_id", "=", config["configurable"]["thread_id"]])
+			checkpoint_ns = config["configurable"].get("checkpoint_ns")
+			if checkpoint_ns is not None:
+				filters.append(["checkpoint_ns", "=", checkpoint_ns])
+			if checkpoint_id := get_checkpoint_id(config):
+				filters.append(["checkpoint_id", "=", checkpoint_id])
+		if before and (before_id := get_checkpoint_id(before)):
+			filters.append(["checkpoint_id", "<", before_id])
+
+		rows = frappe.db.get_all(
+			CHECKPOINT_DOCTYPE,
+			filters=filters,
+			fields=CHECKPOINT_FIELDS,
+			order_by="checkpoint_id desc",
+			# ponytail: metadata lives in an opaque blob, so a metadata filter
+			# is applied in Python over the whole thread. Add indexed metadata
+			# columns if list(filter=...) ever gets hot.
+			limit=None if filter else limit,
+		)
+
+		yielded = 0
+		for row in rows:
+			checkpoint_tuple = self._to_tuple(row)
+			if filter and any(checkpoint_tuple.metadata.get(key) != value for key, value in filter.items()):
+				continue
+
+			yield checkpoint_tuple
+			yielded += 1
+			if limit is not None and yielded >= limit:
+				return
+
+	# --- writing ------------------------------------------------------------
+
+	def put(
+		self,
+		config: RunnableConfig,
+		checkpoint: Checkpoint,
+		metadata: CheckpointMetadata,
+		new_versions: ChannelVersions,
+	) -> RunnableConfig:
+		thread_id = config["configurable"]["thread_id"]
+		checkpoint_ns = config["configurable"].get("checkpoint_ns", "") or ""
+		checkpoint_id = checkpoint["id"]
+
+		# ponytail: `channel_values` is stored inline with the checkpoint
+		# instead of in a separate version-keyed blob table. Simpler, and the
+		# large channels (messages) change nearly every superstep anyway, so a
+		# blob table would deduplicate little. Split it out if thread size hurts.
+		checkpoint_type, checkpoint_data = self._encode(checkpoint)
+		metadata_type, metadata_data = self._encode(get_checkpoint_metadata(config, metadata))
+
+		self._buffer_row(
+			CHECKPOINT_DOCTYPE,
+			checkpoint_row_name(thread_id, checkpoint_ns, checkpoint_id),
+			{
+				"thread_id": thread_id,
+				"checkpoint_ns": checkpoint_ns,
+				"checkpoint_id": checkpoint_id,
+				"parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+				"checkpoint_type": checkpoint_type,
+				"checkpoint_data": checkpoint_data,
+				"metadata_type": metadata_type,
+				"metadata_data": metadata_data,
+			},
+		)
+
+		return {
+			"configurable": {
+				"thread_id": thread_id,
+				"checkpoint_ns": checkpoint_ns,
+				"checkpoint_id": checkpoint_id,
+			}
+		}
+
+	def put_writes(
+		self,
+		config: RunnableConfig,
+		writes: Sequence[tuple[str, Any]],
+		task_id: str,
+		task_path: str = "",
+	) -> None:
+		thread_id = config["configurable"]["thread_id"]
+		checkpoint_ns = config["configurable"].get("checkpoint_ns", "") or ""
+		checkpoint_id = config["configurable"]["checkpoint_id"]
+
+		for position, (channel, value) in enumerate(writes):
+			idx = WRITES_IDX_MAP.get(channel, position)
+			value_type, value_data = self._encode(value)
+			self._buffer_row(
+				CHECKPOINT_WRITE_DOCTYPE,
+				checkpoint_write_row_name(thread_id, checkpoint_ns, checkpoint_id, task_id, idx),
+				{
+					"thread_id": thread_id,
+					"checkpoint_ns": checkpoint_ns,
+					"checkpoint_id": checkpoint_id,
+					"task_id": task_id,
+					"task_path": task_path,
+					"idx": idx,
+					"channel": channel,
+					"value_type": value_type,
+					"value_data": value_data,
+				},
+				keep_first=idx >= 0,
+			)
+
+	def delete_thread(self, thread_id: str) -> None:
+		with self._lock:
+			for key in [key for key, values in self._buffer.items() if values["thread_id"] == thread_id]:
+				del self._buffer[key]
+
+		frappe.db.delete(CHECKPOINT_DOCTYPE, {"thread_id": thread_id})
+		frappe.db.delete(CHECKPOINT_WRITE_DOCTYPE, {"thread_id": thread_id})
+
+	# --- internals ----------------------------------------------------------
+
+	def _buffer_row(
+		self, doctype: str, name: str, values: dict[str, Any], *, keep_first: bool = False
+	) -> None:
+		with self._lock:
+			if keep_first:
+				self._buffer.setdefault((doctype, name), values)
+			else:
+				self._buffer[(doctype, name)] = values
+
+	def _encode(self, value: Any) -> tuple[str, str]:
+		"""Serialize through the LangGraph serde, base64 for a text column."""
+		type_, blob = self.serde.dumps_typed(value)
+		return type_, b64encode(blob).decode()
+
+	def _decode(self, type_: str, data: str | None) -> Any:
+		return self.serde.loads_typed((type_, b64decode(data or "")))
+
+	def _to_tuple(self, row: dict[str, Any]) -> CheckpointTuple:
+		thread_id = row["thread_id"]
+		checkpoint_ns = row["checkpoint_ns"] or ""
+		checkpoint_id = row["checkpoint_id"]
+
+		return CheckpointTuple(
+			config={
+				"configurable": {
+					"thread_id": thread_id,
+					"checkpoint_ns": checkpoint_ns,
+					"checkpoint_id": checkpoint_id,
+				}
+			},
+			checkpoint=self._decode(row["checkpoint_type"], row["checkpoint_data"]),
+			metadata=self._decode(row["metadata_type"], row["metadata_data"]),
+			parent_config=(
+				{
+					"configurable": {
+						"thread_id": thread_id,
+						"checkpoint_ns": checkpoint_ns,
+						"checkpoint_id": row["parent_checkpoint_id"],
+					}
+				}
+				if row["parent_checkpoint_id"]
+				else None
+			),
+			pending_writes=self._pending_writes(thread_id, checkpoint_ns, checkpoint_id),
+		)
+
+	def _pending_writes(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> list[PendingWrite]:
+		rows = frappe.db.get_all(
+			CHECKPOINT_WRITE_DOCTYPE,
+			filters={
+				"thread_id": thread_id,
+				"checkpoint_ns": checkpoint_ns,
+				"checkpoint_id": checkpoint_id,
+			},
+			fields=("task_id", "channel", "value_type", "value_data"),
+			order_by="task_id asc, idx asc",
+		)
+		return [
+			(row["task_id"], row["channel"], self._decode(row["value_type"], row["value_data"]))
+			for row in rows
+		]
+
+	def _upsert(self, doctype: str, name: str, values: dict[str, Any]) -> None:
+		# ponytail: check-then-insert, not an atomic upsert. Two workers writing
+		# the same checkpoint row would need INSERT ... ON DUPLICATE KEY; one
+		# conversation is handled by one worker, so this is enough.
+		if frappe.db.exists(doctype, name):
+			frappe.db.set_value(doctype, name, values, update_modified=False)
+			return
+
+		doc = frappe.new_doc(doctype)
+		doc.update(values)
+		doc.insert(ignore_permissions=True)

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.js
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, ALYF GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Ask ALYF Checkpoint", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.json
@@ -1,0 +1,86 @@
+{
+ "actions": [],
+ "creation": "2026-08-28 16:00:32.062637",
+ "description": "One LangGraph checkpoint. Written by FrappeCheckpointSaver, not by users.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "thread_id",
+  "checkpoint_ns",
+  "checkpoint_id",
+  "parent_checkpoint_id",
+  "checkpoint_type",
+  "checkpoint_data",
+  "metadata_type",
+  "metadata_data"
+ ],
+ "fields": [
+  {
+   "fieldname": "thread_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Thread ID",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "checkpoint_ns",
+   "fieldtype": "Data",
+   "label": "Checkpoint Namespace"
+  },
+  {
+   "fieldname": "checkpoint_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Checkpoint ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "parent_checkpoint_id",
+   "fieldtype": "Data",
+   "label": "Parent Checkpoint ID"
+  },
+  {
+   "fieldname": "checkpoint_type",
+   "fieldtype": "Data",
+   "label": "Checkpoint Type"
+  },
+  {
+   "fieldname": "checkpoint_data",
+   "fieldtype": "Long Text",
+   "label": "Checkpoint Data (base64)"
+  },
+  {
+   "fieldname": "metadata_type",
+   "fieldtype": "Data",
+   "label": "Metadata Type"
+  },
+  {
+   "fieldname": "metadata_data",
+   "fieldtype": "Long Text",
+   "label": "Metadata Data (base64)"
+  }
+ ],
+ "grid_page_length": 50,
+ "links": [],
+ "modified": "2026-08-28 16:00:32.062637",
+ "modified_by": "Administrator",
+ "module": "Ask ALYF",
+ "name": "Ask ALYF Checkpoint",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "delete": 1,
+   "read": 1,
+   "role": "System Manager"
+  }
+ ],
+ "read_only": 1,
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "thread_id"
+}

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2026-08-28 16:00:32.062637",
+ "creation": "2026-08-28 12:00:00",
  "description": "One LangGraph checkpoint. Written by FrappeCheckpointSaver, not by users.",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -64,7 +64,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-28 16:00:32.062637",
+ "modified": "2026-08-28 16:22:37.073330",
  "modified_by": "Administrator",
  "module": "Ask ALYF",
  "name": "Ask ALYF Checkpoint",

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/ask_alyf_checkpoint.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+from ask_alyf.ask_alyf.checkpointer import checkpoint_row_name
+
+
+class AskALYFCheckpoint(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		checkpoint_data: DF.LongText | None
+		checkpoint_id: DF.Data
+		checkpoint_ns: DF.Data | None
+		checkpoint_type: DF.Data | None
+		metadata_data: DF.LongText | None
+		metadata_type: DF.Data | None
+		parent_checkpoint_id: DF.Data | None
+		thread_id: DF.Data
+	# end: auto-generated types
+
+	def autoname(self):
+		# Deterministic name, so the primary key enforces one row per
+		# (thread, namespace, checkpoint) and writes can upsert without a lock.
+		self.name = checkpoint_row_name(self.thread_id, self.checkpoint_ns, self.checkpoint_id)

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/test_ask_alyf_checkpoint.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint/test_ask_alyf_checkpoint.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, ALYF GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestAskALYFCheckpoint(IntegrationTestCase):
+	"""
+	Integration tests for AskALYFCheckpoint.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.js
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, ALYF GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Ask ALYF Checkpoint Write", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2026-08-28 16:00:40.498424",
+ "creation": "2026-08-28 12:00:00",
  "description": "One pending write of a LangGraph checkpoint. Written by FrappeCheckpointSaver, not by users.",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -73,7 +73,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-28 16:00:40.498424",
+ "modified": "2026-08-28 16:23:58.597993",
  "modified_by": "Administrator",
  "module": "Ask ALYF",
  "name": "Ask ALYF Checkpoint Write",

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.json
@@ -1,0 +1,95 @@
+{
+ "actions": [],
+ "creation": "2026-08-28 16:00:40.498424",
+ "description": "One pending write of a LangGraph checkpoint. Written by FrappeCheckpointSaver, not by users.",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "thread_id",
+  "checkpoint_ns",
+  "checkpoint_id",
+  "task_id",
+  "idx",
+  "channel",
+  "task_path",
+  "value_type",
+  "value_data"
+ ],
+ "fields": [
+  {
+   "fieldname": "thread_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Thread ID",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "checkpoint_ns",
+   "fieldtype": "Data",
+   "label": "Checkpoint Namespace"
+  },
+  {
+   "fieldname": "checkpoint_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Checkpoint ID",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "task_id",
+   "fieldtype": "Data",
+   "label": "Task ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "idx",
+   "fieldtype": "Int",
+   "label": "Index"
+  },
+  {
+   "fieldname": "channel",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Channel"
+  },
+  {
+   "fieldname": "task_path",
+   "fieldtype": "Data",
+   "label": "Task Path"
+  },
+  {
+   "fieldname": "value_type",
+   "fieldtype": "Data",
+   "label": "Value Type"
+  },
+  {
+   "fieldname": "value_data",
+   "fieldtype": "Long Text",
+   "label": "Value Data (base64)"
+  }
+ ],
+ "grid_page_length": 50,
+ "links": [],
+ "modified": "2026-08-28 16:00:40.498424",
+ "modified_by": "Administrator",
+ "module": "Ask ALYF",
+ "name": "Ask ALYF Checkpoint Write",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "delete": 1,
+   "read": 1,
+   "role": "System Manager"
+  }
+ ],
+ "read_only": 1,
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "thread_id"
+}

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/ask_alyf_checkpoint_write.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+from ask_alyf.ask_alyf.checkpointer import checkpoint_write_row_name
+
+
+class AskALYFCheckpointWrite(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		channel: DF.Data | None
+		checkpoint_id: DF.Data
+		checkpoint_ns: DF.Data | None
+		idx: DF.Int
+		task_id: DF.Data
+		task_path: DF.Data | None
+		thread_id: DF.Data
+		value_data: DF.LongText | None
+		value_type: DF.Data | None
+	# end: auto-generated types
+
+	def autoname(self):
+		# Deterministic name: one row per (thread, namespace, checkpoint, task, index).
+		self.name = checkpoint_write_row_name(
+			self.thread_id, self.checkpoint_ns, self.checkpoint_id, self.task_id, self.idx
+		)

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/test_ask_alyf_checkpoint_write.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_checkpoint_write/test_ask_alyf_checkpoint_write.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, ALYF GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestAskALYFCheckpointWrite(IntegrationTestCase):
+	"""
+	Integration tests for AskALYFCheckpointWrite.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/ask_alyf_conversation.py
@@ -22,7 +22,19 @@ class AskALYFConversation(Document):
 		title: DF.Data
 	# end: auto-generated types
 
+	def on_trash(self):
+		# Imported here: the checkpointer pulls in LangGraph, which the desk
+		# requests that merely read conversations should not pay for.
+		from ask_alyf.ask_alyf.checkpointer import delete_checkpoints
+
+		delete_checkpoints([self.name])
+
 	@staticmethod
 	def clear_old_logs(days: int = 90):
+		from ask_alyf.ask_alyf.checkpointer import delete_checkpoints
+
 		table = frappe.qb.DocType("Ask ALYF Conversation")
-		frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))
+		expired = table.creation < (Now() - Interval(days=days))
+		# A bulk delete skips `on_trash`, so the checkpoints go first.
+		delete_checkpoints(frappe.qb.from_(table).select(table.name).where(expired).run(pluck=True))
+		frappe.db.delete(table, filters=expired)

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -372,6 +372,40 @@ class UnitTestAskALYFConversation(UnitTestCase):
 		self.assertTrue(messages)
 		self.assertEqual(messages[-1]["content"], "The ToDo TODO-0001 was updated successfully.")
 
+	def test_confirming_the_same_operation_twice_resumes_it_once(self):
+		"""A double-click must not execute the backend write twice.
+
+		The `for_update` row lock serialises the two requests; this covers what
+		the second one finds once the first has committed.
+		"""
+		pending_operation = {
+			"kind": "backend_action",
+			"tool": "set_value",
+			"summary": "Set status",
+			"requires_confirmation": True,
+			"payload": {"doctype": "ToDo", "name": "TODO-0001", "fieldname": "status", "value": "Closed"},
+			"call_id": "call-backend-1",
+		}
+		conversation = self.make_conversation(messages=[], pending_operations=[pending_operation])
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch(
+				"ask_alyf.ask_alyf.api.resume_operation",
+				return_value={"response": "Done", "pending_operations": []},
+			) as resume_call,
+			patch("ask_alyf.ask_alyf.api.frappe.publish_realtime"),
+		):
+			api.confirm_pending_operation(
+				conversation=conversation.name, call_id="call-backend-1", mode=api.MODE_ASK
+			)
+			with self.assertRaises(frappe.ValidationError):
+				api.confirm_pending_operation(
+					conversation=conversation.name, call_id="call-backend-1", mode=api.MODE_ASK
+				)
+
+		resume_call.assert_called_once()
+
 	def test_reject_pending_operation_resumes_the_paused_agent(self):
 		pending_operation = {
 			"kind": "backend_action",

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests import UnitTestCase
+from rq.job import JobStatus
 
 from ask_alyf.ask_alyf import api, tools
 from ask_alyf.ask_alyf.history import history_item_to_native_message
@@ -46,6 +47,36 @@ class UnitTestAskALYFConversation(UnitTestCase):
 		self.assertEqual(response["user_message_id"], user_message["id"])
 		self.assertEqual(enqueue_job.call_args.kwargs["job_id"], job_id)
 		self.assertTrue(enqueue_job.call_args.kwargs["enqueue_after_commit"])
+
+	def test_send_message_refuses_a_second_run_while_one_is_in_flight(self):
+		pending = api.make_message("user", "First", **{api.BACKGROUND_JOB_ID_KEY: "job-1"})
+		conversation = self.make_conversation(messages=[pending])
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch("ask_alyf.ask_alyf.api.get_job_status", return_value=JobStatus.STARTED),
+			patch("ask_alyf.ask_alyf.api.enqueue") as enqueue_job,
+		):
+			with self.assertRaises(frappe.ValidationError):
+				api.send_message(message="Second", conversation=conversation.name, context={})
+
+		enqueue_job.assert_not_called()
+
+		# Once the first run has answered, the next message goes through.
+		conversation.reload()
+		messages = loads(conversation.messages_json, [])
+		messages.append(api.make_message("assistant", "Done"))
+		conversation.messages_json = dumps(messages)
+		conversation.save(ignore_permissions=True)
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch("ask_alyf.ask_alyf.api.get_job_status", return_value=JobStatus.STARTED),
+			patch("ask_alyf.ask_alyf.api.enqueue") as enqueue_job,
+		):
+			api.send_message(message="Second", conversation=conversation.name, context={})
+
+		enqueue_job.assert_called_once()
 
 	def test_get_message_job_status_maps_rq_terminal_states(self):
 		job_id = "job-123"

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -156,6 +156,48 @@ class UnitTestAskALYFConversation(UnitTestCase):
 		self.assertEqual(len(complete_events), 1)
 		self.assertEqual(complete_events[0]["payload"]["pending_operations"], [expected_with_id])
 
+	def test_process_message_job_publishes_tool_calls_with_the_completion(self):
+		"""The streamed message has no metadata, so the steps ride the completion.
+
+		Without this the summary only appears once the conversation is
+		reloaded from the database.
+		"""
+		user_message = api.make_message("user", "How many open ToDos?", mode=api.MODE_ASK)
+		conversation = self.make_conversation(messages=[user_message])
+		tool_calls = [
+			{
+				"call_id": "call-1",
+				"name": "get_count",
+				"args": {"doctype": "ToDo"},
+				"label": "Counting ToDo",
+				"status": "success",
+			}
+		]
+		realtime_calls = []
+
+		def record_realtime(event, payload=None, user=None, **kwargs):
+			realtime_calls.append({"event": event, "payload": payload})
+
+		with patch(
+			"ask_alyf.ask_alyf.api.run_message",
+			return_value={"response": "Seven.", "pending_operations": [], "tool_calls": tool_calls},
+		):
+			with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime", side_effect=record_realtime):
+				api.process_message_job(
+					conversation_name=conversation.name,
+					message="How many open ToDos?",
+					mode=api.MODE_ASK,
+					context_data={},
+					user_message_id=user_message["id"],
+				)
+
+		complete = [c for c in realtime_calls if c["event"] == "ask_alyf_response_complete"]
+		self.assertEqual(complete[0]["payload"]["tool_calls"], tool_calls)
+
+		conversation.reload()
+		stored = loads(conversation.messages_json, [])[-1]
+		self.assertEqual(stored["metadata"]["tool_calls"], tool_calls)
+
 	def test_process_message_job_persists_document_extractions(self):
 		user_message = api.make_message("user", "What is on this invoice?", mode=api.MODE_ASK)
 		conversation = self.make_conversation(messages=[user_message])
@@ -253,7 +295,7 @@ class UnitTestAskALYFConversation(UnitTestCase):
 				}
 			)
 
-	def test_confirm_pending_operation_executes_backend_path(self):
+	def test_confirm_pending_operation_resumes_the_paused_agent(self):
 		pending_operation = {
 			"kind": "backend_action",
 			"tool": "set_value",
@@ -270,32 +312,28 @@ class UnitTestAskALYFConversation(UnitTestCase):
 
 		with patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True):
 			with patch(
-				"ask_alyf.ask_alyf.api.execute_pending_operation",
-				return_value={"name": "TODO-0001", "message": "Updated"},
-			) as execute_operation:
-				with patch(
-					"ask_alyf.ask_alyf.api.run_message",
-					return_value={
-						"response": "The ToDo TODO-0001 was updated successfully.",
-						"pending_operations": [],
-					},
-				) as summarize_call:
-					with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime", side_effect=record_realtime):
-						response = api.confirm_pending_operation(
-							conversation=conversation.name,
-							call_id="call-backend-1",
-							mode=api.MODE_ASK,
-						)
+				"ask_alyf.ask_alyf.api.resume_operation",
+				return_value={
+					"response": "The ToDo TODO-0001 was updated successfully.",
+					"pending_operations": [],
+				},
+			) as resume_call:
+				with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime", side_effect=record_realtime):
+					response = api.confirm_pending_operation(
+						conversation=conversation.name,
+						call_id="call-backend-1",
+						mode=api.MODE_ASK,
+					)
 
-		execute_operation.assert_called_once_with(pending_operation)
-		summarize_call.assert_called_once()
+		# The agent executes the operation itself when it resumes, so the API
+		# only forwards the decision.
+		resume_call.assert_called_once()
+		self.assertEqual(resume_call.call_args.kwargs["call_id"], "call-backend-1")
+		self.assertEqual(resume_call.call_args.kwargs["status"], "approved")
 		status_updates = [
 			call["payload"]["text"] for call in realtime_calls if call["event"] == "ask_alyf_status"
 		]
-		self.assertEqual(status_updates, ["Confirming action...", "Generating response...", ""])
-		system_message = summarize_call.call_args.kwargs["conversation_history"][-1]
-		self.assertEqual(system_message["role"], "system")
-		self.assertIn('"status": "success"', system_message["content"])
+		self.assertEqual(status_updates, ["Confirming action...", ""])
 		self.assertEqual(response["conversation"]["pending_operations"], [])
 
 		conversation.reload()
@@ -303,7 +341,37 @@ class UnitTestAskALYFConversation(UnitTestCase):
 		self.assertTrue(messages)
 		self.assertEqual(messages[-1]["content"], "The ToDo TODO-0001 was updated successfully.")
 
-	def test_frontend_action_result_clears_pending_operation(self):
+	def test_reject_pending_operation_resumes_the_paused_agent(self):
+		pending_operation = {
+			"kind": "backend_action",
+			"tool": "set_value",
+			"summary": "Set status",
+			"requires_confirmation": True,
+			"payload": {"doctype": "ToDo", "name": "TODO-0001", "fieldname": "status", "value": "Closed"},
+			"call_id": "call-backend-1",
+		}
+		conversation = self.make_conversation(messages=[], pending_operations=[pending_operation])
+
+		with patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True):
+			with patch(
+				"ask_alyf.ask_alyf.api.resume_operation",
+				return_value={"response": "Cancelled, nothing was changed.", "pending_operations": []},
+			) as resume_call:
+				response = api.reject_pending_operation(
+					conversation=conversation.name,
+					call_id="call-backend-1",
+					mode=api.MODE_ASK,
+				)
+
+		self.assertEqual(resume_call.call_args.kwargs["status"], "rejected")
+		self.assertEqual(response["conversation"]["pending_operations"], [])
+
+		conversation.reload()
+		messages = loads(conversation.messages_json, [])
+		self.assertEqual(messages[-1]["content"], "Cancelled, nothing was changed.")
+		self.assertTrue(messages[-1]["metadata"].get("rejected_action"))
+
+	def test_auto_frontend_action_result_is_recorded_without_resuming(self):
 		pending_operation = {
 			"kind": "frontend_action",
 			"tool": "set_route",
@@ -313,44 +381,57 @@ class UnitTestAskALYFConversation(UnitTestCase):
 			"call_id": "call-frontend-1",
 		}
 		conversation = self.make_conversation(messages=[], pending_operations=[pending_operation])
-		realtime_calls = []
-
-		def record_realtime(event, payload=None, user=None, **kwargs):
-			realtime_calls.append({"event": event, "payload": payload, "user": user, "kwargs": kwargs})
 
 		with patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True):
-			with patch(
-				"ask_alyf.ask_alyf.api.run_message",
-				return_value={
-					"response": "Opened the Sales Invoice list view in your browser.",
-					"pending_operations": [],
-				},
-			) as summarize_call:
-				with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime", side_effect=record_realtime):
-					response = api.frontend_action_result(
-						conversation=conversation.name,
-						call_id="call-frontend-1",
-						status="success",
-						mode=api.MODE_ASK,
-						result={"route": ["List", "Sales Invoice"]},
-					)
+			with patch("ask_alyf.ask_alyf.api.resume_operation") as resume_call:
+				response = api.frontend_action_result(
+					conversation=conversation.name,
+					call_id="call-frontend-1",
+					status="success",
+					mode=api.MODE_ASK,
+					result={"route": ["List", "Sales Invoice"]},
+				)
 
-		summarize_call.assert_called_once()
-		status_updates = [
-			call["payload"]["text"] for call in realtime_calls if call["event"] == "ask_alyf_status"
-		]
-		self.assertEqual(status_updates, ["Generating response...", ""])
-		system_message = summarize_call.call_args.kwargs["conversation_history"][-1]
-		self.assertEqual(system_message["role"], "system")
-		self.assertIn('"status": "success"', system_message["content"])
+		# An auto-executed action never paused the graph, so there is nothing
+		# to resume.
+		resume_call.assert_not_called()
 		self.assertEqual(response["conversation"]["pending_operations"], [])
 
 		conversation.reload()
 		messages = loads(conversation.messages_json, [])
-		self.assertTrue(messages)
-		self.assertEqual(messages[-1]["content"], "Opened the Sales Invoice list view in your browser.")
 		self.assertEqual(messages[-1]["metadata"].get("frontend_action_status"), "success")
 		self.assertTrue(messages[-1]["metadata"].get("frontend_action_result"))
+
+	def test_confirmable_frontend_action_result_resumes_the_paused_agent(self):
+		pending_operation = {
+			"kind": "frontend_action",
+			"tool": "frm_set_value",
+			"summary": "Set customer on the open form",
+			"requires_confirmation": True,
+			"payload": {"fieldname": "customer", "value": "ACME"},
+			"call_id": "call-frontend-2",
+		}
+		conversation = self.make_conversation(messages=[], pending_operations=[pending_operation])
+
+		with patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True):
+			with patch(
+				"ask_alyf.ask_alyf.api.resume_operation",
+				return_value={"response": "Set the customer to ACME.", "pending_operations": []},
+			) as resume_call:
+				api.frontend_action_result(
+					conversation=conversation.name,
+					call_id="call-frontend-2",
+					status="success",
+					mode=api.MODE_ASK,
+					result={"fieldname": "customer"},
+				)
+
+		self.assertEqual(resume_call.call_args.kwargs["status"], "success")
+		self.assertEqual(resume_call.call_args.kwargs["result"], {"fieldname": "customer"})
+
+		conversation.reload()
+		messages = loads(conversation.messages_json, [])
+		self.assertEqual(messages[-1]["content"], "Set the customer to ACME.")
 
 	def test_show_chart_frontend_action_persists_charts_on_assistant_message(self):
 		assistant_message = api.make_message(

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -9,8 +9,11 @@ from typing import Annotated, TypedDict
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_days, now_datetime
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
 from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
 from langgraph.types import Command, interrupt
 
 from ask_alyf.ask_alyf.checkpointer import (
@@ -18,6 +21,7 @@ from ask_alyf.ask_alyf.checkpointer import (
 	CHECKPOINT_WRITE_DOCTYPE,
 	FrappeCheckpointSaver,
 )
+from ask_alyf.ask_alyf.doctype.ask_alyf_conversation.ask_alyf_conversation import AskALYFConversation
 
 THREAD = "test-checkpointer-thread"
 
@@ -31,6 +35,7 @@ def _config(checkpoint_id: str | None = None, thread: str = THREAD) -> dict:
 
 class _State(TypedDict):
 	steps: Annotated[list[str], operator.add]
+	messages: Annotated[list[AnyMessage], add_messages]
 
 
 class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
@@ -154,7 +159,8 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 
 	def test_graph_resumes_state_from_the_database_across_invocations(self):
 		def append(state: _State) -> _State:
-			return {"steps": [f"step-{len(state['steps']) + 1}"]}
+			step = f"step-{len(state['steps']) + 1}"
+			return {"steps": [step], "messages": [AIMessage(content=step, id=step)]}
 
 		builder = StateGraph(_State)
 		builder.add_node("append", append)
@@ -163,7 +169,7 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		graph = builder.compile(checkpointer=self.saver)
 
 		config = {"configurable": {"thread_id": THREAD}}
-		graph.invoke({"steps": []}, config)
+		graph.invoke({"steps": [], "messages": [HumanMessage(content="go", id="user-1")]}, config)
 		self.saver.flush()
 
 		# A fresh saver proves the state came back from the database, not memory.
@@ -172,6 +178,9 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		second_saver.flush()
 
 		self.assertEqual(resumed["steps"], ["step-1", "step-2"])
+		# LangChain messages survive the round trip unchanged, IDs included.
+		self.assertEqual([m.id for m in resumed["messages"]], ["user-1", "step-1", "step-2"])
+		self.assertIsInstance(resumed["messages"][0], HumanMessage)
 		self.assertEqual(self.saver.get_tuple(config).checkpoint["channel_values"]["steps"], resumed["steps"])
 
 	def test_writes_from_a_background_thread_are_persisted_by_the_flushing_thread(self):
@@ -211,3 +220,58 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		resuming_saver.flush()
 
 		self.assertEqual(resumed["steps"], ["before", "answered-yes"])
+
+	def _make_conversation(self):
+		return frappe.get_doc(
+			doctype="Ask ALYF Conversation",
+			title="Checkpointer Test",
+			status="Active",
+			messages_json="[]",
+		).insert(ignore_permissions=True)
+
+	def _store_state_for(self, conversation_name: str) -> None:
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		self._put(checkpoint_id, thread=conversation_name)
+		self.saver.put_writes(_config(checkpoint_id, thread=conversation_name), [("steps", "x")], "task-1")
+		self.saver.flush()
+		self.assertEqual(frappe.db.count(CHECKPOINT_DOCTYPE, {"thread_id": conversation_name}), 1)
+
+	def _assert_no_state_for(self, conversation_name: str) -> None:
+		for doctype in (CHECKPOINT_DOCTYPE, CHECKPOINT_WRITE_DOCTYPE):
+			self.assertEqual(frappe.db.count(doctype, {"thread_id": conversation_name}), 0)
+
+	def test_deleting_a_conversation_deletes_its_stored_state(self):
+		conversation = self._make_conversation()
+		self._store_state_for(conversation.name)
+
+		conversation.delete(ignore_permissions=True)
+
+		self._assert_no_state_for(conversation.name)
+
+	def test_clearing_old_conversations_deletes_their_stored_state(self):
+		conversation = self._make_conversation()
+		self._store_state_for(conversation.name)
+		frappe.db.set_value(
+			"Ask ALYF Conversation",
+			conversation.name,
+			"creation",
+			add_days(now_datetime(), -120),
+			update_modified=False,
+		)
+
+		AskALYFConversation.clear_old_logs(days=90)
+
+		self.assertFalse(frappe.db.exists("Ask ALYF Conversation", conversation.name))
+		self._assert_no_state_for(conversation.name)
+
+	def test_a_serializer_clone_writes_into_the_same_buffer(self):
+		# LangGraph may swap the saver for a `with_allowlist` clone. Only the
+		# original is flushed by the runner, so both must share one buffer.
+		clone = self.saver.with_allowlist([("ask_alyf", "Thing")])
+		checkpoint = empty_checkpoint()
+		checkpoint["id"] = "00000000-0000-6000-8000-000000000001"
+		clone.put(_config(), checkpoint, {"source": "loop", "step": 0}, {})
+
+		self.saver.flush()
+
+		self.assertEqual(frappe.db.count(CHECKPOINT_DOCTYPE, {"thread_id": THREAD}), 1)

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, ALYF GmbH and Contributors
+# See license.txt
+
+from __future__ import annotations
+
+import operator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Annotated, TypedDict
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from langgraph.checkpoint.base import empty_checkpoint
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
+
+from ask_alyf.ask_alyf.checkpointer import (
+	CHECKPOINT_DOCTYPE,
+	CHECKPOINT_WRITE_DOCTYPE,
+	FrappeCheckpointSaver,
+)
+
+THREAD = "test-checkpointer-thread"
+
+
+def _config(checkpoint_id: str | None = None, thread: str = THREAD) -> dict:
+	configurable = {"thread_id": thread, "checkpoint_ns": ""}
+	if checkpoint_id:
+		configurable["checkpoint_id"] = checkpoint_id
+	return {"configurable": configurable}
+
+
+class _State(TypedDict):
+	steps: Annotated[list[str], operator.add]
+
+
+class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
+	def setUp(self):
+		self.saver = FrappeCheckpointSaver()
+		self.addCleanup(self._clear)
+		self._clear()
+
+	def _clear(self):
+		for doctype in (CHECKPOINT_DOCTYPE, CHECKPOINT_WRITE_DOCTYPE):
+			frappe.db.delete(doctype, {"thread_id": ("like", "test-checkpointer-%")})
+
+	def _put(self, checkpoint_id: str, parent_id: str | None = None, step: int = 0, thread: str = THREAD):
+		checkpoint = empty_checkpoint()
+		checkpoint["id"] = checkpoint_id
+		checkpoint["channel_values"] = {"steps": [f"value-{checkpoint_id}"]}
+		return self.saver.put(
+			_config(parent_id, thread=thread), checkpoint, {"source": "loop", "step": step}, {}
+		)
+
+	def test_put_then_get_tuple_roundtrips_checkpoint_and_metadata(self):
+		self._put("00000000-0000-6000-8000-000000000001", step=1)
+
+		stored = self.saver.get_tuple(_config())
+		self.assertIsNotNone(stored)
+		self.assertEqual(stored.checkpoint["id"], "00000000-0000-6000-8000-000000000001")
+		self.assertEqual(
+			stored.checkpoint["channel_values"]["steps"], ["value-00000000-0000-6000-8000-000000000001"]
+		)
+		self.assertEqual(stored.metadata["step"], 1)
+		self.assertIsNone(stored.parent_config)
+
+	def test_get_tuple_without_id_returns_latest_and_links_parent(self):
+		first = "00000000-0000-6000-8000-000000000001"
+		second = "00000000-0000-6000-8000-000000000002"
+		self._put(first)
+		self._put(second, parent_id=first)
+
+		latest = self.saver.get_tuple(_config())
+		self.assertEqual(latest.checkpoint["id"], second)
+		self.assertEqual(latest.parent_config["configurable"]["checkpoint_id"], first)
+
+		# An explicit ID still reaches the older checkpoint.
+		older = self.saver.get_tuple(_config(first))
+		self.assertEqual(older.checkpoint["id"], first)
+
+	def test_put_is_idempotent_per_checkpoint_id(self):
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		self._put(checkpoint_id, step=1)
+		self._put(checkpoint_id, step=2)
+		self.saver.flush()
+
+		self.assertEqual(frappe.db.count(CHECKPOINT_DOCTYPE, {"thread_id": THREAD}), 1)
+		self.assertEqual(self.saver.get_tuple(_config()).metadata["step"], 2)
+
+	def test_put_writes_keeps_first_regular_write_and_overwrites_special_writes(self):
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		self._put(checkpoint_id)
+		config = _config(checkpoint_id)
+
+		self.saver.put_writes(config, [("steps", "first")], "task-1")
+		self.saver.flush()
+		# Once from the buffer, once against the stored row.
+		self.saver.put_writes(config, [("steps", "ignored")], "task-1")
+		self.saver.put_writes(config, [("steps", "ignored")], "task-1")
+		# `__resume__` is a special channel: it maps to a negative index and
+		# must replace the stored value instead of being skipped.
+		self.saver.put_writes(config, [("__resume__", "one")], "task-1")
+		self.saver.put_writes(config, [("__resume__", "two")], "task-1")
+
+		pending = self.saver.get_tuple(config).pending_writes
+		self.assertEqual(
+			sorted((channel, value) for _, channel, value in pending),
+			[("__resume__", "two"), ("steps", "first")],
+		)
+
+	def test_writes_of_other_tasks_and_threads_are_not_mixed_in(self):
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		self._put(checkpoint_id)
+		config = _config(checkpoint_id)
+		self.saver.put_writes(config, [("steps", "mine")], "task-1")
+		self.saver.put_writes(config, [("steps", "theirs")], "task-2")
+
+		# Same checkpoint ID, different thread: must stay separate.
+		other_thread = "test-checkpointer-other"
+		self._put(checkpoint_id, thread=other_thread)
+		self.saver.put_writes(_config(checkpoint_id, thread=other_thread), [("steps", "elsewhere")], "task-1")
+
+		pending = self.saver.get_tuple(config).pending_writes
+		self.assertEqual(sorted(value for _, _, value in pending), ["mine", "theirs"])
+
+	def test_list_orders_newest_first_and_honours_before_limit_and_filter(self):
+		ids = [f"00000000-0000-6000-8000-00000000000{n}" for n in (1, 2, 3)]
+		parent = None
+		for step, checkpoint_id in enumerate(ids):
+			self._put(checkpoint_id, parent_id=parent, step=step)
+			parent = checkpoint_id
+
+		listed = [tuple_.checkpoint["id"] for tuple_ in self.saver.list(_config())]
+		self.assertEqual(listed, list(reversed(ids)))
+
+		before = [t.checkpoint["id"] for t in self.saver.list(_config(), before=_config(ids[2]))]
+		self.assertEqual(before, [ids[1], ids[0]])
+
+		limited = [t.checkpoint["id"] for t in self.saver.list(_config(), limit=1)]
+		self.assertEqual(limited, [ids[2]])
+
+		filtered = [t.checkpoint["id"] for t in self.saver.list(_config(), filter={"step": 1})]
+		self.assertEqual(filtered, [ids[1]])
+
+	def test_delete_thread_removes_checkpoints_and_writes(self):
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		self._put(checkpoint_id)
+		self.saver.put_writes(_config(checkpoint_id), [("steps", "first")], "task-1")
+
+		self.saver.flush()
+		self.saver.delete_thread(THREAD)
+
+		self.assertIsNone(self.saver.get_tuple(_config()))
+		self.assertEqual(frappe.db.count(CHECKPOINT_WRITE_DOCTYPE, {"thread_id": THREAD}), 0)
+
+	def test_graph_resumes_state_from_the_database_across_invocations(self):
+		def append(state: _State) -> _State:
+			return {"steps": [f"step-{len(state['steps']) + 1}"]}
+
+		builder = StateGraph(_State)
+		builder.add_node("append", append)
+		builder.add_edge(START, "append")
+		builder.add_edge("append", END)
+		graph = builder.compile(checkpointer=self.saver)
+
+		config = {"configurable": {"thread_id": THREAD}}
+		graph.invoke({"steps": []}, config)
+		self.saver.flush()
+
+		# A fresh saver proves the state came back from the database, not memory.
+		second_saver = FrappeCheckpointSaver()
+		resumed = builder.compile(checkpointer=second_saver).invoke({"steps": []}, config)
+		second_saver.flush()
+
+		self.assertEqual(resumed["steps"], ["step-1", "step-2"])
+		self.assertEqual(self.saver.get_tuple(config).checkpoint["channel_values"]["steps"], resumed["steps"])
+
+	def test_writes_from_a_background_thread_are_persisted_by_the_flushing_thread(self):
+		# LangGraph calls put/put_writes on its background executor, where the
+		# Frappe connection of this thread must not be touched.
+		checkpoint_id = "00000000-0000-6000-8000-000000000001"
+		with ThreadPoolExecutor(max_workers=1) as executor:
+			executor.submit(self._put, checkpoint_id).result()
+			executor.submit(
+				self.saver.put_writes, _config(checkpoint_id), [("steps", "from-thread")], "task-1"
+			).result()
+			# Nothing has touched the database yet.
+			self.assertEqual(frappe.db.count(CHECKPOINT_DOCTYPE, {"thread_id": THREAD}), 0)
+
+		stored = self.saver.get_tuple(_config())
+		self.assertEqual(stored.checkpoint["id"], checkpoint_id)
+		self.assertEqual([value for _, _, value in stored.pending_writes], ["from-thread"])
+
+	def test_interrupted_run_resumes_from_the_database_in_a_later_session(self):
+		def ask(state: _State) -> _State:
+			answer = interrupt("confirm?")
+			return {"steps": [f"answered-{answer}"]}
+
+		builder = StateGraph(_State)
+		builder.add_node("ask", ask)
+		builder.add_edge(START, "ask")
+		builder.add_edge("ask", END)
+
+		config = {"configurable": {"thread_id": THREAD}}
+		result = builder.compile(checkpointer=self.saver).invoke({"steps": ["before"]}, config)
+		self.saver.flush()
+		self.assertTrue(result["__interrupt__"])
+
+		# Fresh saver: the pending interrupt is read back from the database.
+		resuming_saver = FrappeCheckpointSaver()
+		resumed = builder.compile(checkpointer=resuming_saver).invoke(Command(resume="yes"), config)
+		resuming_saver.flush()
+
+		self.assertEqual(resumed["steps"], ["before", "answered-yes"])

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -6,24 +6,41 @@ from __future__ import annotations
 import operator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Annotated, TypedDict
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, now_datetime
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
+from langchain.agents import create_agent
+from langchain_core.language_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.types import Command, interrupt
 
+from ask_alyf.ask_alyf.agent import ToolCallLogMiddleware
 from ask_alyf.ask_alyf.checkpointer import (
 	CHECKPOINT_DOCTYPE,
 	CHECKPOINT_WRITE_DOCTYPE,
 	FrappeCheckpointSaver,
 )
 from ask_alyf.ask_alyf.doctype.ask_alyf_conversation.ask_alyf_conversation import AskALYFConversation
+from ask_alyf.ask_alyf.toolset import (
+	OPERATION_INTERRUPT_KEY,
+	ask_alyfRuntime,
+	ask_alyfToolset,
+	clear_messages_on_tool_error,
+)
 
 THREAD = "test-checkpointer-thread"
+
+
+class _ScriptedModel(FakeMessagesListChatModel):
+	"""A model that replays fixed replies, so a run is driven by the test."""
+
+	def bind_tools(self, tools, **kwargs):
+		return self
 
 
 def _config(checkpoint_id: str | None = None, thread: str = THREAD) -> dict:
@@ -220,6 +237,72 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		resuming_saver.flush()
 
 		self.assertEqual(resumed["steps"], ["before", "answered-yes"])
+
+	def test_a_confirmable_tool_pauses_the_agent_and_resumes_from_the_database(self):
+		"""The whole path: propose, checkpoint, confirm in a later request, execute.
+
+		This is the one that would break silently — the tool runs behind the
+		Frappe context wrapper, inside a real tool node, and the confirmation
+		arrives in a different process with a different saver.
+		"""
+		runtime = ask_alyfRuntime(conversation_name=THREAD, mode="Agent", request_context={})
+		tool = clear_messages_on_tool_error(ask_alyfToolset(runtime).set_value)
+		tool_call = {
+			"name": "set_value",
+			"args": {
+				"doctype": "ToDo",
+				"name": "TODO-0001",
+				"fieldname": "status",
+				"value": "Closed",
+			},
+			"id": "call-1",
+		}
+		config = {"configurable": {"thread_id": THREAD}}
+
+		proposing = create_agent(
+			model=_ScriptedModel(responses=[AIMessage(content="", tool_calls=[tool_call])]),
+			tools=[tool],
+			middleware=[ToolCallLogMiddleware(runtime)],
+			checkpointer=self.saver,
+		)
+		result = proposing.invoke({"messages": [HumanMessage("close TODO-0001")]}, config)
+		self.saver.flush()
+
+		operation = result["__interrupt__"][0].value[OPERATION_INTERRUPT_KEY]
+		self.assertEqual(operation["tool"], "set_value")
+		self.assertEqual(operation["payload"]["value"], "Closed")
+		# Nothing ran yet: the agent is holding inside the tool, so the call is
+		# not in the log either.
+		self.assertFalse(any(isinstance(m, ToolMessage) for m in result["messages"]))
+		self.assertEqual(runtime.tool_calls, [])
+
+		# A later request, with its own saver, reads the pause back from the
+		# database and hands over the confirmation.
+		resuming_saver = FrappeCheckpointSaver()
+		resuming = create_agent(
+			model=_ScriptedModel(responses=[AIMessage(content="Closed TODO-0001.")]),
+			tools=[tool],
+			middleware=[ToolCallLogMiddleware(runtime)],
+			checkpointer=resuming_saver,
+		)
+		with patch(
+			"ask_alyf.ask_alyf.tools.execute_pending_operation",
+			return_value={"name": "TODO-0001"},
+		) as execute_operation:
+			resumed = resuming.invoke(
+				Command(resume={"call_id": operation["call_id"], "status": "approved"}),
+				config,
+			)
+		resuming_saver.flush()
+
+		execute_operation.assert_called_once()
+		self.assertNotIn("__interrupt__", resumed)
+		self.assertEqual(resumed["messages"][-1].text, "Closed TODO-0001.")
+		# The confirmed call is logged once, for the conversation to show.
+		self.assertEqual(
+			[(call["name"], call["status"]) for call in runtime.tool_calls],
+			[("set_value", "success")],
+		)
 
 	def _make_conversation(self):
 		return frappe.get_doc(

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -33,6 +33,8 @@ from ask_alyf.ask_alyf.toolset import (
 	ask_alyfRuntime,
 	ask_alyfToolset,
 	clear_messages_on_tool_error,
+	clear_running_steps,
+	read_running_steps,
 )
 
 
@@ -830,6 +832,36 @@ class UnitTestCodeTools(UnitTestCase):
 		)
 		self.assertEqual(published[0][1]["step"]["label"], "Reading ToDo list")
 		self.assertEqual(published[0][1]["conversation"], "TEST-CONVERSATION")
+
+	def test_running_steps_are_readable_while_the_run_is_in_progress(self):
+		"""A viewer elsewhere cannot replay broadcasts, so steps are also cached."""
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+		self.addCleanup(clear_running_steps, "TEST-CONVERSATION")
+
+		runtime.begin_tool_call("call-1", "get_list", {"doctype": "ToDo"}, "Reading ToDo list")
+		self.assertEqual(
+			[(step["label"], step["status"]) for step in read_running_steps("TEST-CONVERSATION")],
+			[("Reading ToDo list", "running")],
+		)
+
+		runtime.finish_tool_call("call-1", "success")
+		runtime.begin_tool_call("call-2", "insert", {"doctype": "ToDo"}, "Creating ToDo")
+		self.assertEqual(
+			[(step["label"], step["status"]) for step in read_running_steps("TEST-CONVERSATION")],
+			[("Reading ToDo list", "success"), ("Creating ToDo", "running")],
+		)
+
+		clear_running_steps("TEST-CONVERSATION")
+		self.assertEqual(read_running_steps("TEST-CONVERSATION"), [])
+
+	def test_a_dropped_step_leaves_the_cached_list(self):
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+		self.addCleanup(clear_running_steps, "TEST-CONVERSATION")
+
+		runtime.begin_tool_call("call-1", "insert", {"doctype": "ToDo"}, "Creating ToDo")
+		runtime.drop_tool_call("call-1")
+
+		self.assertEqual(read_running_steps("TEST-CONVERSATION"), [])
 
 	def test_a_failing_step_broadcast_does_not_break_the_tool_call(self):
 		"""Tools run on threads whose Frappe context we do not control."""

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -1,18 +1,39 @@
 import asyncio
+import contextlib
 import contextvars
+import itertools
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests import UnitTestCase
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.runnables.config import var_child_runnable_config
+from langgraph._internal._constants import (
+	CONFIG_KEY_CHECKPOINT_NS,
+	CONFIG_KEY_SCRATCHPAD,
+	CONFIG_KEY_SEND,
+)
+from langgraph._internal._scratchpad import PregelScratchpad
+from langgraph.errors import GraphInterrupt
 
 from ask_alyf.ask_alyf import tools
-from ask_alyf.ask_alyf.agent import ASK_ALYF_EXCLUDED_TOOLS, ask_alyfAgentRunner, build_chat_model
+from ask_alyf.ask_alyf.agent import (
+	ASK_ALYF_EXCLUDED_TOOLS,
+	_tool_call_label,
+	ask_alyfAgentRunner,
+	build_chat_model,
+)
 from ask_alyf.ask_alyf.history import history_item_to_native_message
-from ask_alyf.ask_alyf.toolset import ask_alyfToolset, clear_messages_on_tool_error
+from ask_alyf.ask_alyf.toolset import (
+	OPERATION_INTERRUPT_KEY,
+	ask_alyfRuntime,
+	ask_alyfToolset,
+	clear_messages_on_tool_error,
+)
 
 
 class FakeSettings(SimpleNamespace):
@@ -47,6 +68,49 @@ class FakeCheckpointer:
 		self.flush_count += 1
 
 
+@contextlib.contextmanager
+def graph_context(resume: Any = None):
+	"""Run a block as if it were a LangGraph node, so tools may call `interrupt()`.
+
+	Without a resume value `interrupt()` raises `GraphInterrupt`; with one it
+	returns that value, which is exactly how a confirmed proposal is resumed.
+	"""
+	counter = itertools.count()
+	scratchpad = PregelScratchpad(
+		step=0,
+		stop=1,
+		call_counter=lambda: next(counter),
+		interrupt_counter=lambda: next(counter),
+		get_null_resume=lambda _consume: resume,
+		resume=[],
+		subgraph_counter=lambda: next(counter),
+	)
+	token = var_child_runnable_config.set(
+		{
+			"configurable": {
+				CONFIG_KEY_SCRATCHPAD: scratchpad,
+				CONFIG_KEY_SEND: lambda _writes: None,
+				CONFIG_KEY_CHECKPOINT_NS: "tools:test",
+			}
+		}
+	)
+	try:
+		yield
+	finally:
+		var_child_runnable_config.reset(token)
+
+
+def proposed_operation(call) -> dict:
+	"""Call a proposal tool and return the operation it paused the graph on."""
+	with graph_context():
+		try:
+			call()
+		except GraphInterrupt as interrupted:
+			return interrupted.args[0][0].value[OPERATION_INTERRUPT_KEY]
+
+	raise AssertionError("the tool returned without proposing an operation")
+
+
 class UnitTestCodeTools(UnitTestCase):
 	def make_runtime(self, *, mode: str = "Ask"):
 		return SimpleNamespace(
@@ -57,7 +121,15 @@ class UnitTestCodeTools(UnitTestCase):
 			pending_operations=[],
 			document_extractions=[],
 			attached_files=[],
+			tool_calls=[],
 			emit_status=lambda _text: None,
+		)
+
+	def make_agent(self, invoke, *, interrupts=()):
+		"""Stand in for the compiled graph, which the runner also asks for state."""
+		return SimpleNamespace(
+			invoke=invoke,
+			get_state=lambda _config: SimpleNamespace(interrupts=interrupts),
 		)
 
 	def make_runner(self, *, allow_code_search: bool, mode: str = "Ask", stored_state: bool = False):
@@ -188,18 +260,19 @@ class UnitTestCodeTools(UnitTestCase):
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
 
-		result = toolset.write_skill(
-			title="Expense Guide",
-			description="Use this skill for expense questions.",
-			roles=["Accounts User", "Employee"],
-			reason="Create reusable expense guidance.",
+		operation = proposed_operation(
+			lambda: toolset.write_skill(
+				title="Expense Guide",
+				description="Use this skill for expense questions.",
+				roles=["Accounts User", "Employee"],
+				reason="Create reusable expense guidance.",
+			)
 		)
 
-		self.assertTrue(result["success"])
-		self.assertEqual(result["proposal"]["tool"], "insert")
-		self.assertEqual(result["proposal"]["payload"]["doctype"], "Ask ALYF Skill")
+		self.assertEqual(operation["tool"], "insert")
+		self.assertEqual(operation["payload"]["doctype"], "Ask ALYF Skill")
 		self.assertEqual(
-			result["proposal"]["payload"]["values"],
+			operation["payload"]["values"],
 			{
 				"title": "Expense Guide",
 				"description": "Use this skill for expense questions.",
@@ -211,14 +284,16 @@ class UnitTestCodeTools(UnitTestCase):
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
 
-		result = toolset.write_skill(
-			title="Expense Guide",
-			description="Use this skill for expense questions.",
-			roles="Accounts User, Employee",
+		operation = proposed_operation(
+			lambda: toolset.write_skill(
+				title="Expense Guide",
+				description="Use this skill for expense questions.",
+				roles="Accounts User, Employee",
+			)
 		)
 
 		self.assertEqual(
-			result["proposal"]["payload"]["values"]["roles"],
+			operation["payload"]["values"]["roles"],
 			[{"role": "Accounts User"}, {"role": "Employee"}],
 		)
 
@@ -345,25 +420,25 @@ class UnitTestCodeTools(UnitTestCase):
 			}
 		).save()
 
-		result = toolset.attach_file("ToDo", "TODO-0001", file_doc.name)
+		operation = proposed_operation(lambda: toolset.attach_file("ToDo", "TODO-0001", file_doc.name))
 
-		self.assertTrue(result["success"])
-		self.assertEqual(result["proposal"]["payload"]["file_id"], file_doc.name)
-		self.assertIn(f"[{file_doc.file_name}](", result["proposal"]["summary"])
-		self.assertIn(file_doc.file_url, result["proposal"]["summary"])
+		self.assertEqual(operation["payload"]["file_id"], file_doc.name)
+		self.assertIn(f"[{file_doc.file_name}](", operation["summary"])
+		self.assertIn(file_doc.file_url, operation["summary"])
 
 	def test_batch_insert_proposal_uses_record_count_summary(self):
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
 		records = [{"description": "Call customer"}, {"description": "Send quotation"}]
 
-		result = toolset.batch_insert("ToDo", records, reason="Imported open tasks.")
+		operation = proposed_operation(
+			lambda: toolset.batch_insert("ToDo", records, reason="Imported open tasks.")
+		)
 
-		self.assertTrue(result["success"])
-		self.assertEqual(result["proposal"]["tool"], "batch_insert")
-		self.assertEqual(result["proposal"]["payload"]["doctype"], "ToDo")
-		self.assertEqual(result["proposal"]["payload"]["records"], records)
-		self.assertEqual(result["proposal"]["summary"], "Create 2 ToDo records")
+		self.assertEqual(operation["tool"], "batch_insert")
+		self.assertEqual(operation["payload"]["doctype"], "ToDo")
+		self.assertEqual(operation["payload"]["records"], records)
+		self.assertEqual(operation["summary"], "Create 2 ToDo records")
 
 	def test_validate_pending_action_payload_rejects_invalid_batch_insert_rows(self):
 		self.assertEqual(
@@ -579,7 +654,7 @@ class UnitTestCodeTools(UnitTestCase):
 			seen["config"] = config
 			return {"messages": [AIMessage(content="Done.")]}
 
-		runner.agent = SimpleNamespace(invoke=invoke)
+		runner.agent = self.make_agent(invoke)
 		runner.run("hello", conversation_history=[])
 
 		self.assertEqual(seen["config"]["configurable"]["thread_id"], "TEST-CONVERSATION")
@@ -587,9 +662,7 @@ class UnitTestCodeTools(UnitTestCase):
 
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")
-		runner.agent = SimpleNamespace(
-			invoke=lambda _input, config=None: {"messages": [AIMessage(content="Done.")]}
-		)
+		runner.agent = self.make_agent(lambda _input, config=None: {"messages": [AIMessage(content="Done.")]})
 		result = runner.run("do something", conversation_history=[])
 		self.assertEqual(result["response"], "Done.")
 		self.assertEqual(result["pending_operations"], [])
@@ -604,7 +677,7 @@ class UnitTestCodeTools(UnitTestCase):
 				{"type": "text", "text": ":)", "annotations": [], "phase": "final_answer"},
 			]
 		)
-		runner.agent = SimpleNamespace(invoke=lambda _input, config=None: {"messages": [response]})
+		runner.agent = self.make_agent(lambda _input, config=None: {"messages": [response]})
 
 		result = runner.run("hello", conversation_history=[])
 
@@ -720,6 +793,146 @@ class UnitTestCodeTools(UnitTestCase):
 		private_db.close.assert_called_once_with()
 		self.assertIs(frappe.local.db, parent_db)
 		self.assertIs(frappe.local.message_log, parent_message_log)
+
+	def test_tool_call_labels_name_the_record_being_worked_on(self):
+		cases = [
+			(("get_list", {"doctype": "Sales Invoice"}), "Reading Sales Invoice list"),
+			(("get_count", {"doctype": "ToDo"}), "Counting ToDo"),
+			(("get", {"doctype": "ToDo", "name": "TODO-0001"}), "Reading ToDo TODO-0001"),
+			(("insert", {"doctype": "Sales Invoice"}), "Creating Sales Invoice"),
+			(("set_value", {"doctype": "ToDo", "name": "TODO-0001"}), "Updating ToDo TODO-0001"),
+			(("submit", {"doctype": "Sales Invoice", "name": "SI-0001"}), "Submitting Sales Invoice SI-0001"),
+			(("task", {"subagent_type": "document-planner"}), "Asking the document-planner specialist"),
+			(("grep", {"pattern": "x"}), "Searching the source code"),
+		]
+		for (name, args), expected in cases:
+			with self.subTest(tool=name):
+				self.assertEqual(_tool_call_label(name, args), expected)
+
+	def test_an_unmapped_tool_still_gets_a_readable_label(self):
+		self.assertEqual(_tool_call_label("some_new_tool", {}), "Some new tool")
+
+	def test_steps_are_published_as_they_start_and_finish(self):
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+		published = []
+
+		with patch(
+			"ask_alyf.ask_alyf.toolset.frappe.publish_realtime",
+			side_effect=lambda event, payload=None, **kwargs: published.append((event, payload)),
+		):
+			runtime.begin_tool_call("call-1", "get_list", {"doctype": "ToDo"}, "Reading ToDo list")
+			runtime.finish_tool_call("call-1", "success")
+
+		self.assertEqual([event for event, _ in published], ["ask_alyf_step", "ask_alyf_step"])
+		self.assertEqual(
+			[payload["step"]["status"] for _, payload in published],
+			["running", "success"],
+		)
+		self.assertEqual(published[0][1]["step"]["label"], "Reading ToDo list")
+		self.assertEqual(published[0][1]["conversation"], "TEST-CONVERSATION")
+
+	def test_a_failing_step_broadcast_does_not_break_the_tool_call(self):
+		"""Tools run on threads whose Frappe context we do not control."""
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+
+		with patch(
+			"ask_alyf.ask_alyf.toolset.frappe.publish_realtime",
+			side_effect=AttributeError("site"),
+		):
+			runtime.begin_tool_call("call-1", "get_list", {"doctype": "ToDo"}, "Reading ToDo list")
+			runtime.finish_tool_call("call-1", "success")
+
+		self.assertEqual([call["status"] for call in runtime.tool_calls], ["success"])
+
+	def test_a_dropped_step_is_removed_from_the_log_and_the_live_list(self):
+		"""A proposal that pauses has not happened, so it must leave no step."""
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+		published = []
+
+		with patch(
+			"ask_alyf.ask_alyf.toolset.frappe.publish_realtime",
+			side_effect=lambda event, payload=None, **kwargs: published.append(payload),
+		):
+			runtime.begin_tool_call("call-1", "insert", {"doctype": "ToDo"}, "Creating ToDo")
+			runtime.drop_tool_call("call-1")
+
+		self.assertEqual(runtime.tool_calls, [])
+		self.assertEqual(published[-1]["step"], {"call_id": "call-1", "status": "dropped"})
+
+	def test_a_repeated_tool_call_is_logged_once(self):
+		"""Resuming re-runs a whole tool node, so its calls arrive twice."""
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode="Agent", request_context={})
+
+		with patch("ask_alyf.ask_alyf.toolset.frappe.publish_realtime"):
+			runtime.begin_tool_call("call-1", "get_list", {"doctype": "ToDo"}, "Reading ToDo list")
+			runtime.finish_tool_call("call-1", "success")
+			runtime.begin_tool_call("call-1", "get_list", {"doctype": "ToDo"}, "Reading ToDo list")
+			runtime.finish_tool_call("call-1", "success")
+
+		self.assertEqual(len(runtime.tool_calls), 1)
+
+	def test_a_wrapped_tool_can_still_pause_the_graph(self):
+		"""Each tool call runs in a fresh context; the graph config must survive it.
+
+		Without it `interrupt()` cannot see the runnable context, and every
+		confirmable operation would fail instead of asking the user.
+		"""
+		runtime = self.make_runtime(mode="Agent")
+		toolset = ask_alyfToolset(runtime)
+		wrapped = clear_messages_on_tool_error(toolset.set_value)
+
+		operation = proposed_operation(
+			lambda: wrapped("ToDo", "TODO-0001", "status", "Closed", reason="Close it.")
+		)
+
+		self.assertEqual(operation["tool"], "set_value")
+		self.assertEqual(operation["payload"]["value"], "Closed")
+
+	def test_a_confirmed_proposal_executes_and_returns_its_result(self):
+		runtime = self.make_runtime(mode="Agent")
+		toolset = ask_alyfToolset(runtime)
+		call_id = proposed_operation(lambda: toolset.set_value("ToDo", "TODO-0001", "status", "Closed"))[
+			"call_id"
+		]
+
+		with patch(
+			"ask_alyf.ask_alyf.tools.execute_pending_operation",
+			return_value={"name": "TODO-0001"},
+		) as execute_operation:
+			with graph_context(resume={"call_id": call_id, "status": "approved"}):
+				result = toolset.set_value("ToDo", "TODO-0001", "status", "Closed")
+
+		execute_operation.assert_called_once()
+		self.assertTrue(result["success"])
+		self.assertEqual(result["result"], {"name": "TODO-0001"})
+
+	def test_a_rejected_proposal_is_reported_without_executing(self):
+		runtime = self.make_runtime(mode="Agent")
+		toolset = ask_alyfToolset(runtime)
+		call_id = proposed_operation(lambda: toolset.set_value("ToDo", "TODO-0001", "status", "Closed"))[
+			"call_id"
+		]
+
+		with patch("ask_alyf.ask_alyf.tools.execute_pending_operation") as execute_operation:
+			with graph_context(resume={"call_id": call_id, "status": "rejected"}):
+				result = toolset.set_value("ToDo", "TODO-0001", "status", "Closed")
+
+		execute_operation.assert_not_called()
+		self.assertFalse(result["success"])
+		self.assertTrue(result["rejected"])
+
+	def test_a_confirmation_for_another_operation_never_executes(self):
+		"""Resume values are matched positionally by LangGraph, so the call_id decides."""
+		runtime = self.make_runtime(mode="Agent")
+		toolset = ask_alyfToolset(runtime)
+
+		with patch("ask_alyf.ask_alyf.tools.execute_pending_operation") as execute_operation:
+			with graph_context(resume={"call_id": "some-other-operation", "status": "approved"}):
+				result = toolset.set_value("ToDo", "TODO-0001", "status", "Closed")
+
+		execute_operation.assert_not_called()
+		self.assertFalse(result["success"])
+		self.assertIn("did not match", result["error"])
 
 	def test_tool_wrapper_isolates_concurrent_copied_contexts(self):
 		parent_db = frappe.local.db

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -33,6 +33,20 @@ class FakeSettings(SimpleNamespace):
 		return "test-key"
 
 
+class FakeCheckpointer:
+	"""Stands in for `FrappeCheckpointSaver` so unit tests stay off the database."""
+
+	def __init__(self, *, stored_state: bool = False):
+		self.stored_state = stored_state
+		self.flush_count = 0
+
+	def get_tuple(self, _config):
+		return object() if self.stored_state else None
+
+	def flush(self):
+		self.flush_count += 1
+
+
 class UnitTestCodeTools(UnitTestCase):
 	def make_runtime(self, *, mode: str = "Ask"):
 		return SimpleNamespace(
@@ -46,12 +60,13 @@ class UnitTestCodeTools(UnitTestCase):
 			emit_status=lambda _text: None,
 		)
 
-	def make_runner(self, *, allow_code_search: bool, mode: str = "Ask"):
+	def make_runner(self, *, allow_code_search: bool, mode: str = "Ask", stored_state: bool = False):
 		runtime = self.make_runtime(mode=mode)
 		runner = object.__new__(ask_alyfAgentRunner)
 		runner.runtime = runtime
 		runner.settings = FakeSettings(allow_code_search=allow_code_search)
 		runner.toolset = ask_alyfToolset(runtime, settings=runner.settings)
+		runner.checkpointer = FakeCheckpointer(stored_state=stored_state)
 		return runner
 
 	def test_build_chat_model_uses_responses_api_for_any_model(self):
@@ -525,7 +540,7 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertNotIn("/private/files/", text)
 		self.assertNotIn("/files/", text)
 
-	def test_build_input_messages_rebuilds_full_history(self):
+	def test_build_input_messages_rebuilds_full_history_without_stored_state(self):
 		runner = self.make_runner(allow_code_search=False, mode="Ask")
 		runner.runtime.conversation_history = [
 			{"role": "user", "content": "one"},
@@ -540,6 +555,35 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertIsInstance(messages[2], SystemMessage)
 		self.assertIsInstance(messages[-1], HumanMessage)
 		self.assertEqual(messages[-1].content, "two")
+
+	def test_build_input_messages_sends_only_unseen_items_with_stored_state(self):
+		runner = self.make_runner(allow_code_search=False, mode="Agent", stored_state=True)
+		runner.runtime.conversation_history = [
+			{"role": "user", "content": "one"},
+			{"role": "assistant", "content": "one-ans"},
+			# Appended by the app after the agent's turn, e.g. an action result.
+			{"role": "system", "content": "result"},
+		]
+		messages = runner._build_input_messages("two")
+		# The checkpointed thread already holds everything up to "one-ans".
+		self.assertEqual(len(messages), 2)
+		self.assertIsInstance(messages[0], SystemMessage)
+		self.assertEqual(messages[0].content, "result")
+		self.assertEqual(messages[-1].content, "two")
+
+	def test_run_flushes_checkpoints_and_passes_the_conversation_thread(self):
+		runner = self.make_runner(allow_code_search=False, mode="Ask", stored_state=True)
+		seen = {}
+
+		def invoke(_input, config=None):
+			seen["config"] = config
+			return {"messages": [AIMessage(content="Done.")]}
+
+		runner.agent = SimpleNamespace(invoke=invoke)
+		runner.run("hello", conversation_history=[])
+
+		self.assertEqual(seen["config"]["configurable"]["thread_id"], "TEST-CONVERSATION")
+		self.assertEqual(runner.checkpointer.flush_count, 1)
 
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -2,13 +2,16 @@ import asyncio
 import contextlib
 import contextvars
 import functools
+import hashlib
 import inspect
+import json
 from dataclasses import dataclass, field
 from typing import Any
-from uuid import uuid4
 
 import frappe
 from frappe import _
+from langchain_core.runnables.config import var_child_runnable_config
+from langgraph.types import interrupt
 
 from ask_alyf.ask_alyf import tools
 from ask_alyf.ask_alyf.history import (
@@ -25,6 +28,21 @@ from ask_alyf.ask_alyf.utils import parse_newline_list
 Scalar = str | int | float | bool | None
 FrappeFilterList = list[list[Scalar | list[Scalar]]]
 
+# Key under which a paused operation travels inside the LangGraph interrupt
+# value, so the API layer can tell our proposals from any other interrupt.
+OPERATION_INTERRUPT_KEY = "ask_alyf_operation"
+
+
+def operation_call_id(kind: str, tool: str, payload: dict[str, Any]) -> str:
+	"""Identify a proposed operation by what it does.
+
+	Resuming an interrupt re-runs the whole tool node, so the id has to be
+	derived from the operation rather than generated, or the resumed call
+	would no longer recognise the confirmation it is being handed.
+	"""
+	key = json.dumps({"kind": kind, "tool": tool, "payload": payload}, sort_keys=True, default=str)
+	return hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()
+
 
 @dataclass
 class ask_alyfRuntime:
@@ -35,6 +53,63 @@ class ask_alyfRuntime:
 	pending_operations: list[dict[str, Any]] = field(default_factory=list)
 	document_extractions: list[dict[str, Any]] = field(default_factory=list)
 	attached_files: list[dict[str, Any]] = field(default_factory=list)
+	tool_calls: list[dict[str, Any]] = field(default_factory=list)
+
+	def begin_tool_call(self, call_id: str, name: str, args: dict[str, Any], label: str):
+		"""Announce a tool call that is starting, and log it for the transcript.
+
+		Resuming an interrupt re-runs a whole tool node, so a call that was
+		already logged keeps its entry rather than appearing twice.
+		"""
+		step = self._find_tool_call(call_id)
+		if step is None:
+			step = {"call_id": call_id, "name": name, "args": args, "label": label}
+			self.tool_calls.append(step)
+
+		step["status"] = "running"
+		self.emit_step(step)
+
+	def finish_tool_call(self, call_id: str, status: str):
+		"""Record how a tool call ended and tell the user."""
+		step = self._find_tool_call(call_id)
+		if step is None:
+			return
+
+		step["status"] = status
+		self.emit_step(step)
+
+	def drop_tool_call(self, call_id: str):
+		"""Forget a tool call that never happened, such as a paused proposal."""
+		step = self._find_tool_call(call_id)
+		if step is None:
+			return
+
+		self.tool_calls.remove(step)
+		self.emit_step({"call_id": call_id, "status": "dropped"})
+
+	def _find_tool_call(self, call_id: str) -> dict[str, Any] | None:
+		for entry in self.tool_calls:
+			if entry["call_id"] == call_id:
+				return entry
+		return None
+
+	def emit_step(self, step: dict[str, Any]):
+		"""Send one step of the agent's work to the current user.
+
+		A copy is sent because the logged step keeps being mutated as the call
+		progresses, and the published payload must show the state it had when
+		it was sent.
+
+		Announcing a step is presentation, so a failure here must never take
+		down the tool call it describes: the agent runs tools on threads whose
+		Frappe context we do not control, and the step is logged either way.
+		"""
+		with contextlib.suppress(Exception):
+			frappe.publish_realtime(
+				"ask_alyf_step",
+				{"conversation": self.conversation_name, "step": dict(step)},
+				user=frappe.session.user,
+			)
 
 	def emit_status(self, text: str):
 		"""Send a short status update to the current user."""
@@ -77,7 +152,14 @@ class ask_alyfToolset:
 		requires_confirmation: bool = True,
 		**payload: Any,
 	) -> dict[str, Any]:
-		"""Create a pending operation proposal and append it to the list."""
+		"""Propose an operation, pausing the graph when the user must decide.
+
+		A confirmable proposal calls ``interrupt()``: the graph stops inside
+		this tool and is checkpointed, so resuming returns the user's decision
+		right here and the tool goes on to produce a real tool result. An
+		auto-executed frontend action never blocks — it is handed to the
+		browser through ``runtime.pending_operations`` instead.
+		"""
 		validation_error = tools.validate_pending_operation_payload(kind, tool, payload)
 		if validation_error:
 			self.runtime.emit_status(validation_error_status)
@@ -94,15 +176,55 @@ class ask_alyfToolset:
 			"reason": reason,
 			"requires_confirmation": bool(requires_confirmation),
 			"payload": payload,
-			"call_id": uuid4().hex,
+			"call_id": operation_call_id(kind, tool, payload),
 		}
-		self.runtime.pending_operations.append(proposal)
+
+		if not requires_confirmation:
+			self.runtime.pending_operations.append(proposal)
+			self.runtime.emit_status(prepared_status)
+			return {
+				"success": True,
+				"requires_confirmation": False,
+				"proposal": proposal,
+			}
+
 		self.runtime.emit_status(prepared_status)
-		return {
-			"success": True,
-			"requires_confirmation": bool(requires_confirmation),
-			"proposal": proposal,
-		}
+		return self._apply_decision(proposal, interrupt({OPERATION_INTERRUPT_KEY: proposal}))
+
+	def _apply_decision(self, proposal: dict[str, Any], decision: Any) -> dict[str, Any]:
+		"""Turn the user's decision on a paused proposal into a tool result."""
+		decision = decision if isinstance(decision, dict) else {}
+		if decision.get("call_id") != proposal["call_id"]:
+			# The resume value is matched to this call by ``call_id`` because
+			# LangGraph matches resume values to interrupts positionally, and
+			# a tool node runs its calls in a thread pool — so with two
+			# confirmable proposals in one node the order is not guaranteed.
+			# Refusing here keeps an unapproved write from executing; the
+			# model re-proposes one operation at a time.
+			return {
+				"success": False,
+				"error": _("That confirmation did not match this operation. Propose it again on its own."),
+			}
+
+		status = (decision.get("status") or "").strip().lower()
+		if status == "rejected":
+			return {
+				"success": False,
+				"rejected": True,
+				"error": _("The user rejected this operation."),
+			}
+
+		if proposal["kind"] == tools.OPERATION_KIND_FRONTEND:
+			# Frontend actions run in the browser; the resume value carries
+			# whatever it reported back.
+			if status == "success":
+				return {"success": True, "result": decision.get("result") or {}}
+			return {
+				"success": False,
+				"error": decision.get("error") or _("The action could not be completed."),
+			}
+
+		return {"success": True, "result": tools.execute_pending_operation(proposal)}
 
 	def _backend_proposal(
 		self,
@@ -174,7 +296,6 @@ class ask_alyfToolset:
 		Returns:
 			A list of matching documents.
 		"""
-		self.runtime.emit_status(_("Fetching list..."))
 		return tools.get_list(
 			doctype=doctype,
 			fields=fields,
@@ -198,7 +319,6 @@ class ask_alyfToolset:
 		Returns:
 			The number of matching documents.
 		"""
-		self.runtime.emit_status(_("Counting documents..."))
 		return tools.get_count(doctype=doctype, filters=filters)
 
 	def get(
@@ -217,7 +337,6 @@ class ask_alyfToolset:
 		Returns:
 			The matching document.
 		"""
-		self.runtime.emit_status(_("Fetching document..."))
 		return tools.get_document(doctype=doctype, name=name, filters=filters)
 
 	def get_value(
@@ -236,7 +355,6 @@ class ask_alyfToolset:
 		Returns:
 			The requested value or values.
 		"""
-		self.runtime.emit_status(_("Fetching value..."))
 		return tools.get_value(doctype=doctype, fieldname=fieldname, filters=filters)
 
 	def get_single_value(self, doctype: str, field: str) -> Any:
@@ -249,7 +367,6 @@ class ask_alyfToolset:
 		Returns:
 			The field value.
 		"""
-		self.runtime.emit_status(_("Fetching single value..."))
 		return tools.get_single_value(doctype=doctype, field=field)
 
 	def get_meta(self, doctype: str) -> dict[str, Any]:
@@ -261,7 +378,6 @@ class ask_alyfToolset:
 		Returns:
 			A metadata dictionary for the DocType.
 		"""
-		self.runtime.emit_status(_("Loading metadata..."))
 		return tools.get_meta(doctype=doctype)
 
 	def has_permission(self, doctype: str, docname: str, perm_type: str = "read") -> dict[str, bool]:
@@ -275,7 +391,6 @@ class ask_alyfToolset:
 		Returns:
 			A dictionary containing the boolean permission result.
 		"""
-		self.runtime.emit_status(_("Checking permissions..."))
 		return tools.has_permission(doctype=doctype, docname=docname, perm_type=perm_type)
 
 	def get_doc_permissions(self, doctype: str, docname: str) -> dict[str, Any]:
@@ -288,7 +403,6 @@ class ask_alyfToolset:
 		Returns:
 			The evaluated permission dictionary.
 		"""
-		self.runtime.emit_status(_("Evaluating permissions..."))
 		return tools.get_doc_permissions(doctype=doctype, docname=docname)
 
 	def list_accessible_doctypes(self, permission_type: str = "read") -> list[str]:
@@ -300,7 +414,6 @@ class ask_alyfToolset:
 		Returns:
 			A list of DocType names.
 		"""
-		self.runtime.emit_status(_("Listing accessible DocTypes..."))
 		return tools.list_accessible_doctypes(permission_type=permission_type)
 
 	def list_accessible_reports(self) -> list[dict[str, Any]]:
@@ -309,7 +422,6 @@ class ask_alyfToolset:
 		Returns:
 			A list of report metadata dictionaries.
 		"""
-		self.runtime.emit_status(_("Listing accessible reports..."))
 		return tools.list_accessible_reports()
 
 	def translate_ui_labels(
@@ -329,7 +441,6 @@ class ask_alyfToolset:
 		Returns:
 			A dictionary with the resolved language and translated labels.
 		"""
-		self.runtime.emit_status(_("Translating UI labels..."))
 		request_language = self.runtime.request_context.get("lang") or self.runtime.request_context.get(
 			"locale"
 		)
@@ -355,7 +466,6 @@ class ask_alyfToolset:
 		Returns:
 			The matching File ID.
 		"""
-		self.runtime.emit_status(_("Resolving file ID..."))
 		return tools.get_file_id(
 			reference_doctype=reference_doctype,
 			reference_name=reference_name,
@@ -373,7 +483,6 @@ class ask_alyfToolset:
 		Returns:
 			The file metadata and content.
 		"""
-		self.runtime.emit_status(_("Reading file..."))
 		return tools.read_file_record(file_id=file_id)
 
 	def extract_document_data(self, file_id: str, extraction_prompt: str = "") -> dict[str, Any]:
@@ -394,7 +503,6 @@ class ask_alyfToolset:
 			A dictionary with the file ID, file name, number of pages processed,
 			and the extracted data as a JSON object.
 		"""
-		self.runtime.emit_status(_("Extracting document data..."))
 		import asyncio
 
 		result = asyncio.run(
@@ -431,7 +539,6 @@ class ask_alyfToolset:
 		Returns:
 			A dictionary with the generated file metadata (name, file_name, file_url).
 		"""
-		self.runtime.emit_status(_("Generating print..."))
 		file_entry = tools.get_print(
 			doctype=doctype,
 			name=name,
@@ -456,7 +563,6 @@ class ask_alyfToolset:
 		Returns:
 			The SQL result rows.
 		"""
-		self.runtime.emit_status(_("Running SQL query..."))
 		return tools.run_read_only_sql(query=query)
 
 	def get_app_version(self, app_name: str) -> str:
@@ -468,7 +574,6 @@ class ask_alyfToolset:
 		Returns:
 			The app version string.
 		"""
-		self.runtime.emit_status(_("Reading app version..."))
 		return tools.get_app_version(app_name=app_name)
 
 	def read_github_releases(self, app_name: str, limit: int = 5) -> list[dict[str, Any]]:
@@ -481,7 +586,6 @@ class ask_alyfToolset:
 		Returns:
 			A list of release dictionaries.
 		"""
-		self.runtime.emit_status(_("Reading GitHub releases..."))
 		return tools.read_github_releases(app_name=app_name, limit=limit)
 
 	def read_documentation_page(self, app_name: str, relative_path: str = "") -> dict[str, Any]:
@@ -494,7 +598,6 @@ class ask_alyfToolset:
 		Returns:
 			A documentation payload containing the page content.
 		"""
-		self.runtime.emit_status(_("Reading documentation..."))
 		return tools.read_documentation_page(app_name=app_name, relative_path=relative_path)
 
 	def read_skill(self, name: str) -> dict[str, str]:
@@ -509,7 +612,6 @@ class ask_alyfToolset:
 		Returns:
 			A dictionary containing the skill name, title, and markdown description.
 		"""
-		self.runtime.emit_status(_("Reading skill..."))
 		skill_doc = get_accessible_skill_doc(name)
 		return {
 			"name": skill_doc.name,
@@ -1027,6 +1129,7 @@ class _CallerFrappeContext:
 	sites_path: str
 	user: str
 	language: str
+	runnable_config: Any
 
 
 def _capture_caller_frappe_context() -> _CallerFrappeContext:
@@ -1035,6 +1138,10 @@ def _capture_caller_frappe_context() -> _CallerFrappeContext:
 		sites_path=frappe.local.sites_path,
 		user=frappe.session.user,
 		language=frappe.local.lang,
+		# Tool calls run in an empty context (below), which would otherwise
+		# strip the LangGraph config that ``interrupt()`` reads to pause the
+		# graph and to match a resume value back to its call.
+		runnable_config=var_child_runnable_config.get(),
 	)
 
 
@@ -1042,6 +1149,7 @@ def _capture_caller_frappe_context() -> _CallerFrappeContext:
 def _private_frappe_context(caller: _CallerFrappeContext):
 	"""Initialize and destroy a private Frappe context for one tool call."""
 	private_db = None
+	var_child_runnable_config.set(caller.runnable_config)
 	try:
 		frappe.init(caller.site, sites_path=caller.sites_path)
 		frappe.connect(set_admin_as_user=False)

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -32,6 +32,25 @@ FrappeFilterList = list[list[Scalar | list[Scalar]]]
 # value, so the API layer can tell our proposals from any other interrupt.
 OPERATION_INTERRUPT_KEY = "ask_alyf_operation"
 
+# Steps of a run in progress are parked in the cache so a viewer that was not
+# watching when they were broadcast can still pick them up. Long enough to
+# outlive any run, short enough that a crashed run leaves nothing behind.
+RUNNING_STEPS_TTL = 60 * 60
+
+
+def running_steps_key(conversation_name: str) -> str:
+	return f"ask_alyf_running_steps:{conversation_name}"
+
+
+def read_running_steps(conversation_name: str) -> list[dict[str, Any]]:
+	"""Return the steps of the run currently working on this conversation."""
+	return frappe.cache().get_value(running_steps_key(conversation_name)) or []
+
+
+def clear_running_steps(conversation_name: str) -> None:
+	"""Forget the steps of a run that is over."""
+	frappe.cache().delete_value(running_steps_key(conversation_name))
+
 
 def operation_call_id(kind: str, tool: str, payload: dict[str, Any]) -> str:
 	"""Identify a proposed operation by what it does.
@@ -109,6 +128,16 @@ class ask_alyfRuntime:
 				"ask_alyf_step",
 				{"conversation": self.conversation_name, "step": dict(step)},
 				user=frappe.session.user,
+			)
+
+		# A broadcast only reaches whoever is looking. The list is also parked
+		# in the cache so a viewer who was in another conversation, or who
+		# reloaded, can pick the run up where it is.
+		with contextlib.suppress(Exception):
+			frappe.cache().set_value(
+				running_steps_key(self.conversation_name),
+				list(self.tool_calls),
+				expires_in_sec=RUNNING_STEPS_TTL,
 			)
 
 	def emit_status(self, text: str):

--- a/ask_alyf/public/css/ask_alyf.bundle.css
+++ b/ask_alyf/public/css/ask_alyf.bundle.css
@@ -1003,3 +1003,94 @@
 		transition: none;
 	}
 }
+
+.ask_alyf-tool-calls,
+.ask_alyf-live-steps {
+	width: 100%;
+	max-width: 100%;
+	font-size: 0.75rem;
+	color: var(--text-muted);
+}
+
+.ask_alyf-tool-calls > summary {
+	cursor: pointer;
+	list-style: none;
+	padding: 0.1rem 0;
+	user-select: none;
+}
+
+.ask_alyf-tool-calls > summary::-webkit-details-marker {
+	display: none;
+}
+
+.ask_alyf-tool-calls > summary::before {
+	content: "▸";
+	display: inline-block;
+	width: 0.9em;
+}
+
+.ask_alyf-tool-calls[open] > summary::before {
+	content: "▾";
+}
+
+.ask_alyf-tool-call-list {
+	margin: 0.2rem 0 0;
+	padding-left: 1.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+}
+
+.ask_alyf-live-steps .ask_alyf-tool-call-list {
+	margin: 0;
+}
+
+.ask_alyf-tool-call-list > li {
+	animation: ask_alyf-step-in 0.18s ease-out;
+}
+
+@keyframes ask_alyf-step-in {
+	from {
+		opacity: 0;
+		transform: translateY(0.25rem);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.ask_alyf-tool-call-name {
+	font-weight: 500;
+}
+
+.ask_alyf-tool-call-args {
+	display: block;
+	overflow-wrap: anywhere;
+	opacity: 0.8;
+}
+
+.ask_alyf-tool-call-running .ask_alyf-tool-call-name {
+	animation: ask_alyf-step-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes ask_alyf-step-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.45;
+	}
+}
+
+.ask_alyf-tool-call-failed .ask_alyf-tool-call-name {
+	color: var(--text-danger, #c0392b);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ask_alyf-tool-call-list > li,
+	.ask_alyf-tool-call-running .ask_alyf-tool-call-name {
+		animation: none;
+	}
+}

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -150,6 +150,7 @@ import "./field_agent";
 				messages: [],
 				pendingOperations: [],
 				status: "",
+				steps: [],
 				mode: "Ask",
 			};
 			this.pendingStreamMessageId = null;
@@ -165,6 +166,7 @@ import "./field_agent";
 			this.activeFrappeCharts = new Map();
 			this.statusWrapperEl = null;
 			this.statusBodyEl = null;
+			this.liveStepsEl = null;
 			this.pendingOperationsEl = null;
 			this.suggestedPromptsEl = null;
 			this.activeResponseJob = null;
@@ -268,6 +270,165 @@ import "./field_agent";
 				return `${getIcon("paperclip", "xs", "", true)} ${names}`;
 			}
 			return this.escapeHtml(message.content || "").replace(/\n/g, "<br>");
+		}
+
+		getToolCallsFingerprint(message) {
+			const toolCalls = message?.metadata?.tool_calls;
+			if (message?.role !== "assistant" || !Array.isArray(toolCalls) || !toolCalls.length) {
+				return "";
+			}
+			try {
+				return JSON.stringify(toolCalls);
+			} catch {
+				return "";
+			}
+		}
+
+		syncMessageToolCalls(entry, message) {
+			const fingerprint = this.getToolCallsFingerprint(message);
+			if (entry.toolCallsFingerprint === fingerprint) {
+				return;
+			}
+
+			entry.toolCallsFingerprint = fingerprint;
+			if (entry.toolCallsHolder) {
+				entry.toolCallsHolder.remove();
+				entry.toolCallsHolder = null;
+			}
+			if (!fingerprint) {
+				return;
+			}
+
+			entry.toolCallsHolder = this.buildToolCallsElement(message.metadata.tool_calls);
+			// Above the body: the agent did these before it answered.
+			entry.wrapper.insertBefore(entry.toolCallsHolder, entry.body);
+		}
+
+		buildToolCallsElement(toolCalls, { open = false } = {}) {
+			const holder = document.createElement("details");
+			holder.className = "ask_alyf-tool-calls";
+			holder.open = open;
+
+			const summary = document.createElement("summary");
+			summary.textContent =
+				toolCalls.length === 1 ? __("1 step") : __("{0} steps", [toolCalls.length]);
+			holder.appendChild(summary);
+
+			const list = document.createElement("ol");
+			list.className = "ask_alyf-tool-call-list";
+			for (const call of toolCalls) {
+				list.appendChild(this.buildToolCallItem(call));
+			}
+			holder.appendChild(list);
+			return holder;
+		}
+
+		buildToolCallItem(call, { showArgs = true } = {}) {
+			const item = document.createElement("li");
+			if (call?.status === "failed") {
+				item.classList.add("ask_alyf-tool-call-failed");
+			}
+			if (call?.status === "running") {
+				item.classList.add("ask_alyf-tool-call-running");
+			}
+
+			const name = document.createElement("span");
+			name.className = "ask_alyf-tool-call-name";
+			// Older messages predate the server-side label and only carry the
+			// raw tool name.
+			name.textContent = call?.label || (call?.name || "").replace(/_/g, " ");
+			item.appendChild(name);
+
+			const args = showArgs ? this.formatToolCallArgs(call?.args) : "";
+			if (args) {
+				const detail = document.createElement("span");
+				detail.className = "ask_alyf-tool-call-args";
+				detail.textContent = args;
+				item.appendChild(detail);
+			}
+
+			return item;
+		}
+
+		applyStepUpdate(step) {
+			if (!step?.call_id) {
+				return;
+			}
+
+			const index = this.state.steps.findIndex((entry) => entry.call_id === step.call_id);
+			if (step.status === "dropped") {
+				if (index !== -1) {
+					this.state.steps.splice(index, 1);
+				}
+			} else if (index === -1) {
+				this.state.steps.push({ ...step });
+			} else {
+				this.state.steps[index] = { ...this.state.steps[index], ...step };
+			}
+
+			this.renderLiveSteps();
+			this.scrollToBottom();
+		}
+
+		adoptCompletedToolCalls(messageId, toolCalls) {
+			if (!Array.isArray(toolCalls) || !toolCalls.length) {
+				return;
+			}
+			const message = this.state.messages.find((item) => item.id === messageId);
+			if (!message) {
+				return;
+			}
+			// Stored steps are authoritative: they survive a reload, the live
+			// ones do not.
+			message.metadata = { ...(message.metadata || {}), tool_calls: toolCalls };
+		}
+
+		clearLiveSteps() {
+			this.state.steps = [];
+			this.renderLiveSteps();
+		}
+
+		renderLiveSteps() {
+			if (!this.messagesEl) {
+				return;
+			}
+
+			if (!this.state.steps.length) {
+				if (this.liveStepsEl) {
+					this.liveStepsEl.remove();
+					this.liveStepsEl = null;
+				}
+				return;
+			}
+
+			// Rebuilt rather than patched: the list is short and only changes
+			// once per tool call.
+			const wrapper = document.createElement("div");
+			wrapper.className = "ask_alyf-message ask_alyf-assistant ask_alyf-live-steps";
+			const list = document.createElement("ol");
+			list.className = "ask_alyf-tool-call-list";
+			for (const step of this.state.steps) {
+				// Labels only while it runs; the arguments are there to read in
+				// the message once the turn is done.
+				list.appendChild(this.buildToolCallItem(step, { showArgs: false }));
+			}
+			wrapper.appendChild(list);
+
+			if (this.liveStepsEl) {
+				this.liveStepsEl.replaceWith(wrapper);
+			} else {
+				this.messagesEl.insertBefore(wrapper, this.statusWrapperEl || this.pendingOperationsEl || null);
+			}
+			this.liveStepsEl = wrapper;
+		}
+
+		formatToolCallArgs(args) {
+			if (!args || typeof args !== "object") {
+				return "";
+			}
+			return Object.entries(args)
+				.map(([key, value]) => `${key}: ${value}`)
+				.join(", ");
 		}
 
 		renderFileLink(fileEntry) {
@@ -412,6 +573,8 @@ import "./field_agent";
 					chartResizeObserver: null,
 					html: null,
 					role: null,
+					toolCallsFingerprint: "",
+					toolCallsHolder: null,
 					wrapper,
 				};
 				this.messageEntries.set(messageKey, entry);
@@ -434,6 +597,7 @@ import "./field_agent";
 				entry.html = html;
 			}
 
+			this.syncMessageToolCalls(entry, message);
 			this.syncMessageCharts(entry, message, messageKey);
 			return { entry, messageKey };
 		}
@@ -707,7 +871,13 @@ import "./field_agent";
 			frappe.realtime.on("ask_alyf_response_start", (message) => {
 				if (message.conversation !== this.state.conversation?.name) return;
 				this.setLoading(true);
+				this.clearLiveSteps();
 				this.setStatus(__("Thinking..."));
+			});
+
+			frappe.realtime.on("ask_alyf_step", (message) => {
+				if (message.conversation !== this.state.conversation?.name) return;
+				this.applyStepUpdate(message.step);
 			});
 
 			frappe.realtime.on("ask_alyf_file_attachment", (message) => {
@@ -729,6 +899,8 @@ import "./field_agent";
 				this.stopResponseJobMonitor();
 				this.setLoading(false);
 				this.setStatus("");
+				this.adoptCompletedToolCalls(message.message_id, message.tool_calls);
+				this.clearLiveSteps();
 				this.state.pendingOperations = this.normalizePendingOperations(message.pending_operations);
 				this.pendingStreamMessageId = null;
 
@@ -785,6 +957,9 @@ import "./field_agent";
 			this.stopResponseJobMonitor();
 			this.pendingStreamMessageId = null;
 			this.handledFrontendCallIds = new Set();
+			// Steps of the run that just finished are part of its assistant
+			// message now, and steps of another conversation are not ours.
+			this.state.steps = [];
 			this.state.conversation = conversation;
 			this.state.messages = conversation.messages || [];
 			this.state.pendingOperations = this.normalizePendingOperations(
@@ -1764,7 +1939,14 @@ import "./field_agent";
 		appendAssistantChunk(messageId, chunk) {
 			let message = this.state.messages.find((item) => item.id === messageId);
 			if (!message) {
-				message = { id: messageId, role: "assistant", content: "" };
+				// The steps that were streaming live belong to this answer, so
+				// they move into it rather than being dropped and re-appearing
+				// once the message is reloaded.
+				message = { id: messageId, role: "assistant", content: "", metadata: {} };
+				if (this.state.steps.length) {
+					message.metadata.tool_calls = this.state.steps.map((step) => ({ ...step }));
+					this.state.steps = [];
+				}
 				this.state.messages.push(message);
 			}
 
@@ -2263,6 +2445,7 @@ import "./field_agent";
 			}
 
 			this.renderedMessageKeys = nextMessageKeys;
+			this.renderLiveSteps();
 			this.renderStatusMessage();
 			this.renderPendingOperation();
 			this.renderSuggestedPrompts();

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -383,6 +383,19 @@ import "./field_agent";
 			message.metadata = { ...(message.metadata || {}), tool_calls: toolCalls };
 		}
 
+		adoptRunningSteps(steps) {
+			// Catches up a view that missed the broadcasts — after switching
+			// conversations, or after a reload. Only a longer list is adopted,
+			// so a poll that lags behind the live stream never rewinds it.
+			if (!Array.isArray(steps) || steps.length <= this.state.steps.length) {
+				return;
+			}
+
+			this.state.steps = steps.map((step) => ({ ...step }));
+			this.renderLiveSteps();
+			this.scrollToBottom();
+		}
+
 		clearLiveSteps() {
 			this.state.steps = [];
 			this.renderLiveSteps();
@@ -1087,6 +1100,7 @@ import "./field_agent";
 			const result = response.message || {};
 			if (result.status === "pending") {
 				activeJob.missingChecks = 0;
+				this.adoptRunningSteps(result.tool_calls);
 				this.scheduleResponseJobPoll(version);
 				return;
 			}

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -430,7 +430,10 @@ import "./field_agent";
 			if (this.liveStepsEl) {
 				this.liveStepsEl.replaceWith(wrapper);
 			} else {
-				this.messagesEl.insertBefore(wrapper, this.statusWrapperEl || this.pendingOperationsEl || null);
+				this.messagesEl.insertBefore(
+					wrapper,
+					this.statusWrapperEl || this.pendingOperationsEl || null,
+				);
 			}
 			this.liveStepsEl = wrapper;
 		}


### PR DESCRIPTION
Gives the agent real persistent state, and then spends it on two things that were previously faked: human-in-the-loop confirmations, and a visible log of what the agent did.

## 1. `FrappeCheckpointSaver`

A LangGraph checkpointer on the Frappe ORM — `Ask ALYF Checkpoint` + `Ask ALYF Checkpoint Write`, keyed by conversation name as `thread_id`. No second datastore.

Three things worth knowing while reviewing it:

- **Threading.** LangGraph runs `put`/`put_writes` on its own executor, and a Frappe DB connection belongs to the thread that opened it. Writes are buffered in memory and drained by `flush()` on the request thread. Reads flush first, so the database stays the single source of truth.
- **Transactions.** Nothing is committed in the saver. Checkpoints ride the request's transaction, so stored graph state and the conversation document roll back together.
- **Sync only.** The async `BaseCheckpointSaver` methods raise `NotImplementedError` on purpose — a Frappe connection is not usable from another thread or event loop.

Deletion is wired to `on_trash` and to `clear_old_logs` (which bulk-deletes and so skips `on_trash` — checkpoints go first).

Subagent runs are checkpointed too, under the same `thread_id` with a `tools:<task-call-id>` namespace: deepagents compiles them without a checkpointer, but Pregel falls back to the ambient config. Those rows are write-only in practice — the namespace is fresh per delegation — so they only make a mid-subagent interrupt resumable.

## 2. Confirmations are real interrupts now

A write tool used to return a proposal, the run ended, and a separate `continue_after_action` endpoint re-entered the agent with a hand-built acknowledgement message. That machinery is gone (~300 lines): the tool now calls `interrupt()` and the confirmation resumes the paused graph, so the tool returns the real outcome to the model in its own turn.

Two things this needed:

- **`interrupt()` inside our tools.** `clear_messages_on_tool_error` runs each tool in a fresh `contextvars.Context()`, which stripped `var_child_runnable_config` and made `get_config()` raise. The caller's runnable config is now captured and restored. Load-bearing — without it every confirmable tool raises `RuntimeError` instead of pausing.
- **Content-derived `call_id`.** LangGraph matches resume values to interrupts *positionally*, and `ToolNode` runs its calls in a thread pool, so with two parallel proposals a confirmation could land on the wrong operation and execute an unapproved write. The id is now a hash of `(kind, tool, payload)` and `_apply_decision` refuses a decision whose `call_id` does not match. The system prompt also mandates one write tool per step.

## 3. Tool calls in the chat, as they happen

`ToolCallLogMiddleware` wraps every tool call and emits a step (`running` → `success`/`failed`) with a user-facing label — "Reading Sales Invoice list", "Creating ToDo", "Asking the Sales Invoice specialist" — rather than the tool name. Steps stream over `ask_alyf_step`, build up live above the response, and graduate onto the assistant message when it arrives, so the history keeps them.

A paused proposal drops its step: it hasn't happened yet, and the tool node re-executes on resume.

Because a broadcast only reaches whoever is looking, the in-flight list is also parked in the Frappe cache (`ask_alyf_running_steps:{conversation}`, 1h TTL, cleared at both ends of a run) and returned by the existing job-status poll. Switching conversations or reloading recovers the steps within ~2s. The poller only adopts a *longer* list, so it can never rewind the live stream.

## 4. One run per conversation

A conversation is now a single-threaded resource, because two runs against one `thread_id` fork the stored graph state and race on `messages_json`.

- **New messages.** `job_id` was a fresh uuid per message, so RQ deduplication did nothing. `send_message` takes a row lock on the conversation and refuses to enqueue while a job is still pending.
- **Operation resolutions.** `confirm`/`reject`/`frontend_action_result` all read the pending operation, resume the paused agent synchronously, and only persist the removal once the run returns. Two overlapping requests — a double-clicked confirm button is enough — would both see it as pending and both resume the same checkpoint, **executing the backend write twice**. All three now load through `lock_conversation()`, so the second request waits and then finds the operation gone.

An atomic upsert in the checkpointer would not have fixed either case: rows are named by `checkpoint_id`, a fresh uuid per step, so concurrent runs diverge long before they collide on a row. The coordination has to be at the entry point.

## Behaviour changes

- The model is now told to call **one write tool at a time** (it previously proposed them all at once). `batch_insert` still covers bulk same-doctype work.
- A second `send_message` on a busy conversation throws instead of queueing. The UI already disables input while loading, so this only fires from a second tab.
- Per-tool `emit_status` calls were removed — the step list replaces the status indicator.

## Known ceiling

If the model calls `show_chart` *and* a write tool in the same step, the interrupt discards the node's work and the chart proposal is re-emitted on resume, so it renders under both assistant messages. Rare, and the one-write-at-a-time prompt makes it rarer.

## Tests

`test_checkpointer.py` covers the saver (including a full `create_agent` run that pauses on a confirmable tool and resumes from the database with two savers). `test_code_tools.py` covers the interrupt/resume path, the mismatched-confirmation refusal, labels, and step publishing — one of those tests caught a real bug where the live step dict was published by reference and both events serialized as `success`. Conversation tests cover confirm/reject/frontend resume, tool calls riding the completion event, and the concurrent-run guard.
