### PR TITLE
fix: preserve committed operation outcome on follow-up errors

### DIFF
--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -37,6 +37,8 @@ from ask_alyf.ask_alyf.toolset import (
 	clear_messages_on_tool_error,
 )
 
+OPERATION_RESUME_SAVEPOINT = "ask_alyf_operation_resume"
+
 
 def _on_tool_error(exc: Exception, request: ToolCallRequest) -> str:
 	"""Convert a tool exception into content for an error ToolMessage.
@@ -502,7 +504,23 @@ Mode awareness and behavior:
 	def resume(self, call_id: str, status: str, **decision: Any) -> dict[str, Any]:
 		"""Continue a run that paused on a proposal, with the user's decision."""
 		command = Command(resume={"call_id": call_id, "status": status, **decision})
-		return self._finish(self.agent.invoke(command, config=self.thread_config))
+		frappe.db.savepoint(OPERATION_RESUME_SAVEPOINT)
+		try:
+			return self._finish(self.agent.invoke(command, config=self.thread_config))
+		except Exception:
+			frappe.db.rollback(save_point=OPERATION_RESUME_SAVEPOINT)
+			if not self.runtime.backend_operation_committed:
+				raise
+
+			frappe.log_error("Ask ALYF Action Follow-Up Error")
+			frappe.clear_messages()
+			return {
+				"response": _(
+					"The operation was completed, but the follow-up response could not be generated."
+				),
+				"pending_operations": [],
+				"tool_calls": self.runtime.tool_calls,
+			}
 
 	def _finish(self, result: Any) -> dict[str, Any]:
 		# LangGraph checkpoints from its background threads, which must not use

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -509,10 +509,17 @@ Mode awareness and behavior:
 			return self._finish(self.agent.invoke(command, config=self.thread_config))
 		except Exception:
 			frappe.db.rollback(save_point=OPERATION_RESUME_SAVEPOINT)
-			self.checkpointer.delete_thread(self.runtime.conversation_name)
 			if not self.runtime.backend_operation_committed:
+				# Nothing was written and nothing was flushed, so the thread is
+				# still paused on this proposal: keep it, so a confirmation that
+				# failed on the way to the backend can be tried again.
 				raise
 
+			# The write landed on the tool's own connection while the thread
+			# never recorded its outcome. Resuming that stale pause would run
+			# the write a second time, so the thread goes and the next turn is
+			# seeded from the stored conversation history instead.
+			self.checkpointer.delete_thread(self.runtime.conversation_name)
 			frappe.log_error("Ask ALYF Action Follow-Up Error")
 			frappe.clear_messages()
 			return {

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -509,6 +509,7 @@ Mode awareness and behavior:
 			return self._finish(self.agent.invoke(command, config=self.thread_config))
 		except Exception:
 			frappe.db.rollback(save_point=OPERATION_RESUME_SAVEPOINT)
+			self.checkpointer.delete_thread(self.runtime.conversation_name)
 			if not self.runtime.backend_operation_committed:
 				raise
 
@@ -519,6 +520,8 @@ Mode awareness and behavior:
 					"The operation was completed, but the follow-up response could not be generated."
 				),
 				"pending_operations": [],
+				"document_extractions": self.runtime.document_extractions,
+				"attached_files": self.runtime.attached_files,
 				"tool_calls": self.runtime.tool_calls,
 			}
 

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -656,7 +656,6 @@ def confirm_pending_operation(conversation: str, call_id: str = "", mode: str = 
 		frappe.throw(_("Only backend actions can be confirmed by this endpoint."))
 
 	remaining = [op for op in all_operations if op.get("call_id") != pending_operation.get("call_id")]
-	doc.pending_operation_json = dumps(remaining) if remaining else ""
 
 	publish_status_update(doc.name, doc.owner, _("Confirming action..."))
 	try:
@@ -672,6 +671,10 @@ def confirm_pending_operation(conversation: str, call_id: str = "", mode: str = 
 		ack_meta = {"confirmed_action": True, "action_status": "success" if agent_result else "failed"}
 
 		if agent_result:
+			# Only a resume that returned took the proposal off the agent; no
+			# result means nothing was written and the operation stays pending
+			# so the user can confirm again.
+			doc.pending_operation_json = dumps(remaining) if remaining else ""
 			apply_agent_result_to_conversation(
 				doc,
 				messages,

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -372,6 +372,34 @@ class UnitTestAskALYFConversation(UnitTestCase):
 		self.assertTrue(messages)
 		self.assertEqual(messages[-1]["content"], "The ToDo TODO-0001 was updated successfully.")
 
+	def test_a_failed_confirmation_keeps_the_operation_pending(self):
+		"""Nothing was written, so the proposal must survive for a second try."""
+		pending_operation = {
+			"kind": "backend_action",
+			"tool": "set_value",
+			"summary": "Set status",
+			"requires_confirmation": True,
+			"payload": {"doctype": "ToDo", "name": "TODO-0001", "fieldname": "status", "value": "Closed"},
+			"call_id": "call-backend-1",
+		}
+		conversation = self.make_conversation(messages=[], pending_operations=[pending_operation])
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch("ask_alyf.ask_alyf.api.resume_operation", side_effect=RuntimeError("boom")),
+			patch("ask_alyf.ask_alyf.api.frappe.log_error"),
+			patch("ask_alyf.ask_alyf.api.frappe.publish_realtime"),
+		):
+			response = api.confirm_pending_operation(
+				conversation=conversation.name, call_id="call-backend-1", mode=api.MODE_ASK
+			)
+
+		self.assertEqual(len(response["conversation"]["pending_operations"]), 1)
+		conversation.reload()
+		self.assertEqual(loads(conversation.pending_operation_json, [])[0]["call_id"], "call-backend-1")
+		messages = loads(conversation.messages_json, [])
+		self.assertIn("Could not complete the operation", messages[-1]["content"])
+
 	def test_confirming_the_same_operation_twice_resumes_it_once(self):
 		"""A double-click must not execute the backend write twice.
 

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -713,7 +713,8 @@ class UnitTestCodeTools(UnitTestCase):
 			runner.resume("operation-1", "approved")
 
 		rollback.assert_called_once_with(save_point="ask_alyf_operation_resume")
-		self.assertEqual(runner.checkpointer.deleted_threads, ["TEST-CONVERSATION"])
+		# The proposal is still pending in the thread, so it can be confirmed again.
+		self.assertEqual(runner.checkpointer.deleted_threads, [])
 
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -124,6 +124,7 @@ class UnitTestCodeTools(UnitTestCase):
 			document_extractions=[],
 			attached_files=[],
 			tool_calls=[],
+			backend_operation_committed=False,
 			emit_status=lambda _text: None,
 		)
 
@@ -662,6 +663,48 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertEqual(seen["config"]["configurable"]["thread_id"], "TEST-CONVERSATION")
 		self.assertEqual(runner.checkpointer.flush_count, 1)
 
+	def test_resume_reports_a_committed_operation_when_follow_up_fails(self):
+		runner = self.make_runner(allow_code_search=False, mode="Agent")
+		runner.runtime.backend_operation_committed = True
+		runner.runtime.tool_calls = [{"name": "set_value", "status": "success"}]
+
+		def fail_after_commit(_input, config=None):
+			raise RuntimeError("boom")
+
+		runner.agent = self.make_agent(fail_after_commit)
+
+		with (
+			patch("ask_alyf.ask_alyf.agent.frappe.db.savepoint") as savepoint,
+			patch("ask_alyf.ask_alyf.agent.frappe.db.rollback") as rollback,
+			patch("ask_alyf.ask_alyf.agent.frappe.log_error") as log_error,
+			patch("ask_alyf.ask_alyf.agent.frappe.clear_messages") as clear_messages,
+		):
+			result = runner.resume("operation-1", "approved")
+
+		self.assertIn("operation was completed", result["response"])
+		self.assertEqual(result["pending_operations"], [])
+		self.assertEqual(result["tool_calls"], runner.runtime.tool_calls)
+		savepoint.assert_called_once_with("ask_alyf_operation_resume")
+		rollback.assert_called_once_with(save_point="ask_alyf_operation_resume")
+		log_error.assert_called_once_with("Ask ALYF Action Follow-Up Error")
+		clear_messages.assert_called_once_with()
+
+	def test_resume_still_raises_when_the_operation_did_not_commit(self):
+		runner = self.make_runner(allow_code_search=False, mode="Agent")
+
+		def fail_before_commit(_input, config=None):
+			raise RuntimeError("boom")
+
+		runner.agent = self.make_agent(fail_before_commit)
+		with (
+			patch("ask_alyf.ask_alyf.agent.frappe.db.savepoint"),
+			patch("ask_alyf.ask_alyf.agent.frappe.db.rollback") as rollback,
+			self.assertRaisesRegex(RuntimeError, "boom"),
+		):
+			runner.resume("operation-1", "approved")
+
+		rollback.assert_called_once_with(save_point="ask_alyf_operation_resume")
+
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")
 		runner.agent = self.make_agent(lambda _input, config=None: {"messages": [AIMessage(content="Done.")]})
@@ -923,20 +966,21 @@ class UnitTestCodeTools(UnitTestCase):
 	def test_a_confirmed_proposal_executes_and_returns_its_result(self):
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
-		call_id = proposed_operation(lambda: toolset.set_value("ToDo", "TODO-0001", "status", "Closed"))[
-			"call_id"
-		]
+		wrapped = clear_messages_on_tool_error(toolset.set_value)
+		call_id = proposed_operation(lambda: wrapped("ToDo", "TODO-0001", "status", "Closed"))["call_id"]
+		self.assertFalse(getattr(runtime, "backend_operation_committed", False))
 
 		with patch(
 			"ask_alyf.ask_alyf.tools.execute_pending_operation",
 			return_value={"name": "TODO-0001"},
 		) as execute_operation:
 			with graph_context(resume={"call_id": call_id, "status": "approved"}):
-				result = toolset.set_value("ToDo", "TODO-0001", "status", "Closed")
+				result = wrapped("ToDo", "TODO-0001", "status", "Closed")
 
 		execute_operation.assert_called_once()
 		self.assertTrue(result["success"])
 		self.assertEqual(result["result"], {"name": "TODO-0001"})
+		self.assertTrue(runtime.backend_operation_committed)
 
 	def test_a_rejected_proposal_is_reported_without_executing(self):
 		runtime = self.make_runtime(mode="Agent")

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -62,12 +62,16 @@ class FakeCheckpointer:
 	def __init__(self, *, stored_state: bool = False):
 		self.stored_state = stored_state
 		self.flush_count = 0
+		self.deleted_threads = []
 
 	def get_tuple(self, _config):
 		return object() if self.stored_state else None
 
 	def flush(self):
 		self.flush_count += 1
+
+	def delete_thread(self, thread_id):
+		self.deleted_threads.append(thread_id)
 
 
 @contextlib.contextmanager
@@ -666,6 +670,8 @@ class UnitTestCodeTools(UnitTestCase):
 	def test_resume_reports_a_committed_operation_when_follow_up_fails(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")
 		runner.runtime.backend_operation_committed = True
+		runner.runtime.document_extractions = [{"supplier": "Example"}]
+		runner.runtime.attached_files = [{"name": "FILE-0001"}]
 		runner.runtime.tool_calls = [{"name": "set_value", "status": "success"}]
 
 		def fail_after_commit(_input, config=None):
@@ -683,7 +689,10 @@ class UnitTestCodeTools(UnitTestCase):
 
 		self.assertIn("operation was completed", result["response"])
 		self.assertEqual(result["pending_operations"], [])
+		self.assertEqual(result["document_extractions"], runner.runtime.document_extractions)
+		self.assertEqual(result["attached_files"], runner.runtime.attached_files)
 		self.assertEqual(result["tool_calls"], runner.runtime.tool_calls)
+		self.assertEqual(runner.checkpointer.deleted_threads, ["TEST-CONVERSATION"])
 		savepoint.assert_called_once_with("ask_alyf_operation_resume")
 		rollback.assert_called_once_with(save_point="ask_alyf_operation_resume")
 		log_error.assert_called_once_with("Ask ALYF Action Follow-Up Error")
@@ -704,6 +713,7 @@ class UnitTestCodeTools(UnitTestCase):
 			runner.resume("operation-1", "approved")
 
 		rollback.assert_called_once_with(save_point="ask_alyf_operation_resume")
+		self.assertEqual(runner.checkpointer.deleted_threads, ["TEST-CONVERSATION"])
 
 	def test_run_preserves_result_envelope_and_proposal_shapes(self):
 		runner = self.make_runner(allow_code_search=False, mode="Agent")

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -73,6 +73,7 @@ class ask_alyfRuntime:
 	document_extractions: list[dict[str, Any]] = field(default_factory=list)
 	attached_files: list[dict[str, Any]] = field(default_factory=list)
 	tool_calls: list[dict[str, Any]] = field(default_factory=list)
+	backend_operation_committed: bool = False
 
 	def begin_tool_call(self, call_id: str, name: str, args: dict[str, Any], label: str):
 		"""Announce a tool call that is starting, and log it for the transcript.
@@ -157,6 +158,11 @@ class ask_alyfRuntime:
 	def remember_attached_file(self, file_entry: dict[str, Any]):
 		"""Store a file attachment to be shown in the conversation history."""
 		self.attached_files.append(file_entry)
+
+
+_private_context_backend_runtime: contextvars.ContextVar[ask_alyfRuntime | None] = contextvars.ContextVar(
+	"private_context_backend_runtime", default=None
+)
 
 
 class ask_alyfToolset:
@@ -253,7 +259,9 @@ class ask_alyfToolset:
 				"error": decision.get("error") or _("The action could not be completed."),
 			}
 
-		return {"success": True, "result": tools.execute_pending_operation(proposal)}
+		result = tools.execute_pending_operation(proposal)
+		_private_context_backend_runtime.set(self.runtime)
+		return {"success": True, "result": result}
 
 	def _backend_proposal(
 		self,
@@ -1178,6 +1186,7 @@ def _capture_caller_frappe_context() -> _CallerFrappeContext:
 def _private_frappe_context(caller: _CallerFrappeContext):
 	"""Initialize and destroy a private Frappe context for one tool call."""
 	private_db = None
+	pending_runtime_token = _private_context_backend_runtime.set(None)
 	var_child_runnable_config.set(caller.runnable_config)
 	try:
 		frappe.init(caller.site, sites_path=caller.sites_path)
@@ -1187,6 +1196,8 @@ def _private_frappe_context(caller: _CallerFrappeContext):
 		frappe.local.lang = caller.language
 		yield
 		private_db.commit()
+		if runtime := _private_context_backend_runtime.get():
+			runtime.backend_operation_committed = True
 	except BaseException:
 		if private_db is not None:
 			with contextlib.suppress(Exception):
@@ -1194,6 +1205,7 @@ def _private_frappe_context(caller: _CallerFrappeContext):
 		frappe.clear_messages()
 		raise
 	finally:
+		_private_context_backend_runtime.reset(pending_runtime_token)
 		with contextlib.suppress(Exception):
 			frappe.destroy()
 


### PR DESCRIPTION
Todo: cherry-pick into backports of #107