### PR TITLE
feat: allow stopping requests

### DIFF
--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -12,7 +12,7 @@ from deepagents import (
 )
 from frappe import _
 from langchain.agents import create_agent
-from langchain.agents.middleware import AgentMiddleware, ToolErrorMiddleware
+from langchain.agents.middleware import AgentMiddleware, ToolErrorMiddleware, hook_config
 from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import AnyMessage, HumanMessage
 from langchain_openai import ChatOpenAI
@@ -35,6 +35,7 @@ from ask_alyf.ask_alyf.toolset import (
 	ask_alyfRuntime,
 	ask_alyfToolset,
 	clear_messages_on_tool_error,
+	is_stop_requested,
 )
 
 OPERATION_RESUME_SAVEPOINT = "ask_alyf_operation_resume"
@@ -171,6 +172,21 @@ class ToolCallLogMiddleware(AgentMiddleware):
 	def __init__(self, runtime: ask_alyfRuntime):
 		super().__init__()
 		self.runtime = runtime
+
+	@hook_config(can_jump_to=["end"])
+	def before_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+		"""End the run here if the user pressed stop.
+
+		Between two model calls every tool call already has its result, so the
+		thread stays valid for the next turn and the checkpoint keeps the work
+		done so far. A stop pressed during a long tool call — a subagent
+		delegation, say — therefore lands once that call returns.
+		"""
+		if not is_stop_requested(self.runtime.conversation_name):
+			return None
+
+		self.runtime.stop_requested = True
+		return {"jump_to": "end"}
 
 	def wrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Any]) -> Any:
 		call = request.tool_call
@@ -562,10 +578,15 @@ Mode awareness and behavior:
 		# here, or — for a run that died mid-flight — in `_run_graph`.
 		self.checkpointer.flush()
 		result_messages = result.get("messages") if isinstance(result, dict) else None
-		response_text = result_messages[-1].text.strip() if result_messages else ""
+		# A stopped run ends wherever it stood, so its last message is whatever
+		# happened to be there — a tool result, or the user's own text. Nothing
+		# in it is an answer, so the caller words the outcome instead.
+		stopped = self.runtime.stop_requested
+		response_text = "" if stopped else (result_messages[-1].text.strip() if result_messages else "")
 
 		return {
 			"response": response_text,
+			"stopped": stopped,
 			"pending_operations": [*self.runtime.pending_operations, *_interrupted_operations(result)],
 			"document_extractions": self.runtime.document_extractions,
 			"attached_files": self.runtime.attached_files,

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -14,7 +14,7 @@ from frappe import _
 from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware, ToolErrorMiddleware, hook_config
 from langchain.agents.middleware.types import ToolCallRequest
-from langchain_core.messages import AnyMessage, HumanMessage
+from langchain_core.messages import AnyMessage, HumanMessage, ToolMessage
 from langchain_openai import ChatOpenAI
 from langgraph.errors import GraphBubbleUp
 from langgraph.types import Command
@@ -191,6 +191,19 @@ class ToolCallLogMiddleware(AgentMiddleware):
 	def wrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Any]) -> Any:
 		call = request.tool_call
 		call_id = call.get("id") or ""
+		# The model plans a whole batch of calls at once and the graph runs the
+		# batch in one step, so ending the run at the next model call would
+		# still pay for every call in it. Skipping them here keeps the answer
+		# each one owes, so the thread stays valid for the next turn, and costs
+		# nothing but the cache read.
+		if is_stop_requested(self.runtime.run_id):
+			self.runtime.stop_requested = True
+			return ToolMessage(
+				content="Stopped by the user before this ran.",
+				name=call.get("name") or "",
+				tool_call_id=call_id,
+			)
+
 		self.runtime.begin_tool_call(
 			call_id,
 			call.get("name") or "",

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -461,6 +461,11 @@ Mode awareness and behavior:
 					),
 					"system_prompt": SOURCE_CODE_ANALYZER_INSTRUCTIONS,
 					"tools": [],
+					# Reading source is where a run spends the most, so this
+					# specialist carries the log middleware too: its reads show
+					# up as steps, and a stop reaches it instead of waiting for
+					# the whole delegation to finish.
+					"middleware": [build_tool_error_middleware(), ToolCallLogMiddleware(self.runtime)],
 					"response_format": SourceCodeAnalysisResult,
 				}
 			)

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -182,7 +182,7 @@ class ToolCallLogMiddleware(AgentMiddleware):
 		done so far. A stop pressed during a long tool call — a subagent
 		delegation, say — therefore lands once that call returns.
 		"""
-		if not is_stop_requested(self.runtime.conversation_name):
+		if not is_stop_requested(self.runtime.run_id):
 			return None
 
 		self.runtime.stop_requested = True
@@ -634,12 +634,14 @@ def run_message(
 	mode: str,
 	request_context: dict[str, Any],
 	conversation_history: list[dict[str, Any]],
+	run_id: str = "",
 ) -> dict[str, Any]:
 	runtime = ask_alyfRuntime(
 		conversation_name=conversation_name,
 		mode=mode,
 		request_context=request_context,
 		conversation_history=conversation_history,
+		run_id=run_id,
 	)
 	runner = ask_alyfAgentRunner(runtime)
 	return runner.run(message, conversation_history)

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -454,7 +454,6 @@ def send_message(
 	doc.last_context_json = dumps(context_data)
 	doc.pending_operation_json = ""
 	save_messages(doc, messages)
-	clear_stop_request(doc.name)
 
 	# An agent turn runs many model round trips and can read source, so the
 	# short queue's 300s death penalty kills it mid-run and the turn's
@@ -480,19 +479,35 @@ def send_message(
 
 
 @frappe.whitelist(methods=["POST"])
-def stop_message(conversation: str) -> dict:
-	"""Ask the run working on this conversation to stop at its next step.
+def stop_message(conversation: str, user_message_id: str, job_id: str) -> dict:
+	"""Ask the run started by this message to stop at its next step.
 
 	Cooperative on purpose: the run ends between two model calls, so it keeps
 	the steps it finished and the conversation stays usable. Killing the worker
 	would be immediate and would throw all of that away.
+
+	The stop names the run it means. Two runs that overlap on one conversation
+	carry different messages and different jobs, so neither can stop the other.
 	"""
 	if not can_access_ask_alyf():
 		frappe.throw(_("You do not have access to Ask ALYF."))
 
 	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
 	doc.check_permission("read")
-	request_stop(doc.name)
+	user_message = next(
+		(
+			item
+			for item in get_messages(doc)
+			if item.get("role") == "user" and item.get("id") == user_message_id
+		),
+		None,
+	)
+	if user_message is None:
+		frappe.throw(_("The message could not be found in this conversation."))
+	if (user_message.get("metadata") or {}).get(BACKGROUND_JOB_ID_KEY) != job_id:
+		frappe.throw(_("The background job does not match this message."))
+
+	request_stop(user_message_id)
 	return {"stopping": True}
 
 
@@ -574,6 +589,7 @@ def process_message_job(
 			mode=mode,
 			request_context=context_data,
 			conversation_history=history,
+			run_id=user_message_id or "",
 		)
 		response = result.get("response") or ""
 		pending_operations = result.get("pending_operations") or []
@@ -602,7 +618,7 @@ def process_message_job(
 		attached_files = None
 		tool_calls = None
 	finally:
-		clear_stop_request(conversation_name)
+		clear_stop_request(user_message_id or "")
 
 	file_message = None
 	if isinstance(attached_files, list) and attached_files:

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -19,7 +19,12 @@ from ask_alyf.ask_alyf.tools import (
 	get_settings,
 	validate_frappe_charts_payload,
 )
-from ask_alyf.ask_alyf.toolset import clear_running_steps, read_running_steps
+from ask_alyf.ask_alyf.toolset import (
+	clear_running_steps,
+	clear_stop_request,
+	read_running_steps,
+	request_stop,
+)
 from ask_alyf.ask_alyf.utils import chunk_text, dumps, loads
 
 MODE_ASK = "Ask"
@@ -449,6 +454,7 @@ def send_message(
 	doc.last_context_json = dumps(context_data)
 	doc.pending_operation_json = ""
 	save_messages(doc, messages)
+	clear_stop_request(doc.name)
 
 	# An agent turn runs many model round trips and can read source, so the
 	# short queue's 300s death penalty kills it mid-run and the turn's
@@ -471,6 +477,23 @@ def send_message(
 		"user_message_id": user_message["id"],
 		"job_id": job_id,
 	}
+
+
+@frappe.whitelist(methods=["POST"])
+def stop_message(conversation: str) -> dict:
+	"""Ask the run working on this conversation to stop at its next step.
+
+	Cooperative on purpose: the run ends between two model calls, so it keeps
+	the steps it finished and the conversation stays usable. Killing the worker
+	would be immediate and would throw all of that away.
+	"""
+	if not can_access_ask_alyf():
+		frappe.throw(_("You do not have access to Ask ALYF."))
+
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc.check_permission("read")
+	request_stop(doc.name)
+	return {"stopping": True}
 
 
 @frappe.whitelist()
@@ -561,6 +584,8 @@ def process_message_job(
 		tool_calls = result.get("tool_calls")
 		if pending_operations and not response:
 			response = _("I've prepared the operation. Please review and confirm.")
+		if result.get("stopped") and not response:
+			response = _("Stopped. Send a message to pick up from here.")
 	except frappe.ValidationError as exc:
 		frappe.clear_messages()
 		response = str(exc)
@@ -576,6 +601,8 @@ def process_message_job(
 		document_extractions = None
 		attached_files = None
 		tool_calls = None
+	finally:
+		clear_stop_request(conversation_name)
 
 	file_message = None
 	if isinstance(attached_files, list) and attached_files:

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -38,6 +38,7 @@ from ask_alyf.ask_alyf.toolset import (
 )
 
 THREAD = "test-checkpointer-thread"
+RUN = "test-checkpointer-run"
 
 
 class _ScriptedModel(FakeMessagesListChatModel):
@@ -381,7 +382,7 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		self.assertEqual(stored.checkpoint["channel_values"]["steps"], ["step-1"])
 
 	def test_pressing_stop_ends_the_run_before_the_next_model_call(self):
-		runtime = ask_alyfRuntime(conversation_name=THREAD, mode="Ask", request_context={})
+		runtime = ask_alyfRuntime(conversation_name=THREAD, mode="Ask", request_context={}, run_id=RUN)
 		agent = create_agent(
 			model=_ScriptedModel(responses=[AIMessage(content="the answer")]),
 			tools=[],
@@ -389,9 +390,9 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 			checkpointer=self.saver,
 		)
 		config = {"configurable": {"thread_id": THREAD}}
-		self.addCleanup(clear_stop_request, THREAD)
+		self.addCleanup(clear_stop_request, RUN)
 
-		request_stop(THREAD)
+		request_stop(RUN)
 		stopped = agent.invoke({"messages": [HumanMessage("something slow")]}, config)
 		self.saver.flush()
 
@@ -402,7 +403,7 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		self.assertIsNotNone(FrappeCheckpointSaver().get_tuple(_config()))
 
 		# Once the flag is gone the same agent runs normally again.
-		clear_stop_request(THREAD)
+		clear_stop_request(RUN)
 		runtime.stop_requested = False
 		resumed = agent.invoke({"messages": [HumanMessage("go on")]}, config)
 		self.saver.flush()

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -33,6 +33,8 @@ from ask_alyf.ask_alyf.toolset import (
 	ask_alyfRuntime,
 	ask_alyfToolset,
 	clear_messages_on_tool_error,
+	clear_stop_request,
+	request_stop,
 )
 
 THREAD = "test-checkpointer-thread"
@@ -377,6 +379,34 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		# A fresh saver proves the flush reached the database, not just memory.
 		stored = FrappeCheckpointSaver().get_tuple(_config())
 		self.assertEqual(stored.checkpoint["channel_values"]["steps"], ["step-1"])
+
+	def test_pressing_stop_ends_the_run_before_the_next_model_call(self):
+		runtime = ask_alyfRuntime(conversation_name=THREAD, mode="Ask", request_context={})
+		agent = create_agent(
+			model=_ScriptedModel(responses=[AIMessage(content="the answer")]),
+			tools=[],
+			middleware=[ToolCallLogMiddleware(runtime)],
+			checkpointer=self.saver,
+		)
+		config = {"configurable": {"thread_id": THREAD}}
+		self.addCleanup(clear_stop_request, THREAD)
+
+		request_stop(THREAD)
+		stopped = agent.invoke({"messages": [HumanMessage("something slow")]}, config)
+		self.saver.flush()
+
+		# The model was never reached, and the turn is stored, so the next
+		# message continues from here instead of starting over.
+		self.assertTrue(runtime.stop_requested)
+		self.assertEqual([m.content for m in stopped["messages"]], ["something slow"])
+		self.assertIsNotNone(FrappeCheckpointSaver().get_tuple(_config()))
+
+		# Once the flag is gone the same agent runs normally again.
+		clear_stop_request(THREAD)
+		runtime.stop_requested = False
+		resumed = agent.invoke({"messages": [HumanMessage("go on")]}, config)
+		self.saver.flush()
+		self.assertEqual(resumed["messages"][-1].content, "the answer")
 
 	def test_a_serializer_clone_writes_into_the_same_buffer(self):
 		# LangGraph may swap the saver for a `with_allowlist` clone. Only the

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -119,18 +119,12 @@ def proposed_operation(call) -> dict:
 
 class UnitTestCodeTools(UnitTestCase):
 	def make_runtime(self, *, mode: str = "Ask"):
-		return SimpleNamespace(
-			conversation_name="TEST-CONVERSATION",
-			mode=mode,
-			request_context={},
-			conversation_history=[],
-			pending_operations=[],
-			document_extractions=[],
-			attached_files=[],
-			tool_calls=[],
-			backend_operation_committed=False,
-			emit_status=lambda _text: None,
-		)
+		# The real dataclass, so a new field on it cannot break these tests
+		# without breaking the code they cover.
+		runtime = ask_alyfRuntime(conversation_name="TEST-CONVERSATION", mode=mode, request_context={})
+		# Status updates would go to a browser that is not there.
+		runtime.emit_status = lambda _text: None
+		return runtime
 
 	def make_agent(self, invoke, *, interrupts=()):
 		"""Stand in for the compiled graph, which the runner also asks for state."""

--- a/ask_alyf/ask_alyf/test_tool_error_middleware.py
+++ b/ask_alyf/ask_alyf/test_tool_error_middleware.py
@@ -10,7 +10,12 @@ from frappe.tests import UnitTestCase
 from langchain_core.messages import ToolMessage
 
 from ask_alyf.ask_alyf import api
-from ask_alyf.ask_alyf.agent import _on_tool_error, build_tool_error_middleware
+from ask_alyf.ask_alyf.agent import (
+	ToolCallLogMiddleware,
+	_on_tool_error,
+	build_tool_error_middleware,
+)
+from ask_alyf.ask_alyf.toolset import ask_alyfRuntime
 from ask_alyf.ask_alyf.utils import dumps, loads
 
 
@@ -41,6 +46,32 @@ class UnitTestToolErrorMiddleware(UnitTestCase):
 		self.assertIn("RuntimeError", content)
 		self.assertNotIn("secret", content)
 		self.assertNotIn("postgres://", content)
+
+	def test_a_stopped_run_skips_the_rest_of_the_planned_tool_calls(self):
+		# The model plans several calls at once. Once the user has pressed stop,
+		# none of the ones that have not started yet may run.
+		runtime = ask_alyfRuntime(
+			conversation_name="TEST-CONVERSATION", mode="Ask", request_context={}, run_id="run-1"
+		)
+		middleware = ToolCallLogMiddleware(runtime)
+		request = SimpleNamespace(
+			tool=SimpleNamespace(name="get_meta"),
+			tool_call={"name": "get_meta", "args": {}, "id": "call-1"},
+		)
+
+		def handler(_request):
+			raise AssertionError("the tool ran after the user pressed stop")
+
+		with patch("ask_alyf.ask_alyf.agent.is_stop_requested", return_value=True):
+			result = middleware.wrap_tool_call(request, handler)
+
+		# The call still gets its answer, so the stored thread stays valid.
+		self.assertIsInstance(result, ToolMessage)
+		self.assertEqual(result.tool_call_id, "call-1")
+		self.assertIn("Stopped", result.content)
+		self.assertTrue(runtime.stop_requested)
+		# A call that never ran is not a step worth showing.
+		self.assertEqual(runtime.tool_calls, [])
 
 	def test_tool_error_middleware_returns_error_tool_message_instead_of_raising(self):
 		middleware = build_tool_error_middleware()

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -42,29 +42,38 @@ def running_steps_key(conversation_name: str) -> str:
 	return f"ask_alyf_running_steps:{conversation_name}"
 
 
-def stop_request_key(conversation_name: str) -> str:
-	return f"ask_alyf_stop_requested:{conversation_name}"
+# A stop belongs to one run, never to the conversation: two runs that overlap
+# on one conversation must not read or clear each other's flag. The run is
+# identified by the user message that started it, which is unique per run and
+# already known to the browser, the job and the stored history.
+def stop_request_key(run_id: str) -> str:
+	return f"ask_alyf_stop_requested:{run_id}"
 
 
-def request_stop(conversation_name: str) -> None:
-	"""Ask the run working on this conversation to end at its next step."""
-	frappe.cache().set_value(stop_request_key(conversation_name), 1, expires_in_sec=RUNNING_STEPS_TTL)
+def request_stop(run_id: str) -> None:
+	"""Ask one run to end at its next step."""
+	frappe.cache().set_value(stop_request_key(run_id), 1, expires_in_sec=RUNNING_STEPS_TTL)
 
 
-def is_stop_requested(conversation_name: str) -> bool:
-	"""Has the user pressed stop on the run working on this conversation?
+def is_stop_requested(run_id: str) -> bool:
+	"""Has the user pressed stop on this run?
 
 	Read from the agent's own threads, where a cache miss and a broken Frappe
 	context look the same: either way the answer is "keep going", so a flaky
-	read can only delay the stop to the next step, never invent one.
+	read can only delay the stop to the next step, never invent one. A run
+	without an id — a resume, which the browser waits on — cannot be stopped.
 	"""
+	if not run_id:
+		return False
+
 	with contextlib.suppress(Exception):
-		return bool(frappe.cache().get_value(stop_request_key(conversation_name)))
+		return bool(frappe.cache().get_value(stop_request_key(run_id)))
 	return False
 
 
-def clear_stop_request(conversation_name: str) -> None:
-	frappe.cache().delete_value(stop_request_key(conversation_name))
+def clear_stop_request(run_id: str) -> None:
+	if run_id:
+		frappe.cache().delete_value(stop_request_key(run_id))
 
 
 def read_running_steps(conversation_name: str) -> list[dict[str, Any]]:
@@ -99,6 +108,7 @@ class ask_alyfRuntime:
 	attached_files: list[dict[str, Any]] = field(default_factory=list)
 	tool_calls: list[dict[str, Any]] = field(default_factory=list)
 	backend_operation_committed: bool = False
+	run_id: str = ""
 	stop_requested: bool = False
 
 	def begin_tool_call(self, call_id: str, name: str, args: dict[str, Any], label: str):

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -42,6 +42,31 @@ def running_steps_key(conversation_name: str) -> str:
 	return f"ask_alyf_running_steps:{conversation_name}"
 
 
+def stop_request_key(conversation_name: str) -> str:
+	return f"ask_alyf_stop_requested:{conversation_name}"
+
+
+def request_stop(conversation_name: str) -> None:
+	"""Ask the run working on this conversation to end at its next step."""
+	frappe.cache().set_value(stop_request_key(conversation_name), 1, expires_in_sec=RUNNING_STEPS_TTL)
+
+
+def is_stop_requested(conversation_name: str) -> bool:
+	"""Has the user pressed stop on the run working on this conversation?
+
+	Read from the agent's own threads, where a cache miss and a broken Frappe
+	context look the same: either way the answer is "keep going", so a flaky
+	read can only delay the stop to the next step, never invent one.
+	"""
+	with contextlib.suppress(Exception):
+		return bool(frappe.cache().get_value(stop_request_key(conversation_name)))
+	return False
+
+
+def clear_stop_request(conversation_name: str) -> None:
+	frappe.cache().delete_value(stop_request_key(conversation_name))
+
+
 def read_running_steps(conversation_name: str) -> list[dict[str, Any]]:
 	"""Return the steps of the run currently working on this conversation."""
 	return frappe.cache().get_value(running_steps_key(conversation_name)) or []
@@ -74,6 +99,7 @@ class ask_alyfRuntime:
 	attached_files: list[dict[str, Any]] = field(default_factory=list)
 	tool_calls: list[dict[str, Any]] = field(default_factory=list)
 	backend_operation_committed: bool = False
+	stop_requested: bool = False
 
 	def begin_tool_call(self, call_id: str, name: str, args: dict[str, Any], label: str):
 		"""Announce a tool call that is starting, and log it for the transcript.

--- a/ask_alyf/public/css/ask_alyf.bundle.css
+++ b/ask_alyf/public/css/ask_alyf.bundle.css
@@ -928,9 +928,12 @@
 }
 
 .ask_alyf-loading .ask_alyf-send {
+	gap: 0.35rem;
+}
+
+.ask_alyf-send:disabled {
 	opacity: 0.72;
 	pointer-events: none;
-	gap: 0.35rem;
 }
 
 .ask_alyf-composer .ask_alyf-send {

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -1092,6 +1092,7 @@ import "./field_agent";
 				version,
 			};
 			this.scheduleResponseJobPoll(version);
+			this.updateSendButton();
 		}
 
 		scheduleResponseJobPoll(version) {
@@ -1744,7 +1745,10 @@ import "./field_agent";
 			// While a run is in flight the same button stops it, so the user is
 			// never left watching a spinner with no way out.
 			this.sendEl.textContent = this.state.loading ? __("Stop") : __("Send");
-			this.sendEl.disabled = Boolean(this.state.stopping);
+			// Until the run reports its job there is nothing to name in a stop,
+			// so the button waits rather than dropping the click.
+			this.sendEl.disabled =
+				Boolean(this.state.stopping) || (this.state.loading && !this.activeResponseJob);
 			this.sendEl.title = this.state.loading ? __("Stop this run") : "";
 		}
 
@@ -1757,8 +1761,10 @@ import "./field_agent";
 		}
 
 		async stopMessage() {
-			const conversation = this.state.conversation?.name;
-			if (!conversation || this.state.stopping) {
+			// The stop names the run it means, so it cannot reach a later run
+			// that started on the same conversation in the meantime.
+			const activeJob = this.activeResponseJob;
+			if (!activeJob || this.state.stopping) {
 				return;
 			}
 
@@ -1772,7 +1778,11 @@ import "./field_agent";
 				await frappe.call({
 					method: "ask_alyf.ask_alyf.api.stop_message",
 					type: "POST",
-					args: { conversation },
+					args: {
+						conversation: activeJob.conversation,
+						user_message_id: activeJob.userMessageId,
+						job_id: activeJob.jobId,
+					},
 				});
 			} catch (error) {
 				this.state.stopping = false;

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -889,7 +889,7 @@ import "./field_agent";
 
 			root.querySelector(".ask_alyf-bubble").addEventListener("click", () => this.toggle(true));
 			root.querySelector(".ask_alyf-close").addEventListener("click", () => this.toggle(false));
-			root.querySelector(".ask_alyf-send").addEventListener("click", () => this.sendMessage());
+			root.querySelector(".ask_alyf-send").addEventListener("click", () => this.handleSendClick());
 			root
 				.querySelector(".ask_alyf-new-chat")
 				.addEventListener("click", () => this.startNewConversation());
@@ -1726,11 +1726,60 @@ import "./field_agent";
 
 		setLoading(value) {
 			this.state.loading = value;
+			if (!value) {
+				this.state.stopping = false;
+			}
 			this.root.classList.toggle("ask_alyf-loading", value);
 			if (this.sendEl) {
 				this.sendEl.setAttribute("aria-busy", value ? "true" : "false");
 			}
+			this.updateSendButton();
 			this.renderStatusMessage();
+		}
+
+		updateSendButton() {
+			if (!this.sendEl) {
+				return;
+			}
+			// While a run is in flight the same button stops it, so the user is
+			// never left watching a spinner with no way out.
+			this.sendEl.textContent = this.state.loading ? __("Stop") : __("Send");
+			this.sendEl.disabled = Boolean(this.state.stopping);
+			this.sendEl.title = this.state.loading ? __("Stop this run") : "";
+		}
+
+		handleSendClick() {
+			if (this.state.loading) {
+				this.stopMessage();
+				return;
+			}
+			this.sendMessage();
+		}
+
+		async stopMessage() {
+			const conversation = this.state.conversation?.name;
+			if (!conversation || this.state.stopping) {
+				return;
+			}
+
+			this.state.stopping = true;
+			this.updateSendButton();
+			this.setStatus(__("Stopping..."));
+
+			try {
+				// The run ends at its next step and writes its own closing
+				// message, which the job monitor picks up like any other reply.
+				await frappe.call({
+					method: "ask_alyf.ask_alyf.api.stop_message",
+					type: "POST",
+					args: { conversation },
+				});
+			} catch (error) {
+				this.state.stopping = false;
+				this.updateSendButton();
+				this.setStatus(__("Processing..."));
+				frappe.msgprint(error.message || __("Failed to stop the run."));
+			}
 		}
 
 		setStatus(text) {


### PR DESCRIPTION
## Problem

While a run works on a message, the send button is disabled and shows a spinner. The user cannot end the run. A long run therefore blocks the conversation until it finishes or the job times out.

## Solution

The send button turns into a stop button while a run is in flight. The stop is cooperative. The run ends between two model calls, so it keeps the steps it finished and the conversation stays usable.

1. The user clicks **Stop**. The browser calls `stop_message` with the conversation, the user message and the job. The endpoint checks that the three belong together and sets a flag in the cache under the message id.
2. Before each tool call, `ToolCallLogMiddleware.wrap_tool_call` reads the flag. If the flag is set, the wrapper answers the call with a `ToolMessage` and does not run the tool.
3. Before each model call, `ToolCallLogMiddleware.before_model` reads the flag. If the flag is set, the middleware returns `{"jump_to": "end"}`.
4. The graph ends the normal way. `_finish` flushes the checkpoint, so the stored thread stays valid and the next message continues from that point.
5. The job writes the closing message *Stopped. Send a message to pick up from here.* The job monitor picks it up like any other reply.

A hard kill of the RQ worker would need less code, but it would throw away the whole turn. This branch keeps the work the user already paid for.

## Why the run is checked twice

The model plans a batch of tool calls in one response, and the graph runs the whole batch in one step. A check before the next model call alone would therefore still pay for every call in the batch. Tool results cost tokens, so the tool wrapper checks first and skips the calls that have not started.

A skipped call still gets a `ToolMessage` with its own `tool_call_id`. A tool call without a result would make the stored history unusable for the next turn.

The check before the model call ends the run. At that point every tool call has its answer, either from the tool or from the skip.

## Changes

| File | Change |
| --- | --- |
| `toolset.py` | `request_stop`, `is_stop_requested` and `clear_stop_request` on `frappe.cache()`, next to the running steps keys and with the same TTL. New `run_id` and `stop_requested` fields on `ask_alyfRuntime`. |
| `agent.py` | `before_model` hook that ends the run, and a `wrap_tool_call` check that skips the tool calls the model already planned. `_finish` reports `stopped` and drops the last message text, because a stopped run does not end on an answer. The `source-code-analyzer` subagent gets the same middleware, so a stop reaches it and its reads show up as steps. |
| `api.py` | New whitelisted `stop_message(conversation, user_message_id, job_id)`. The job passes its message id to `run_message` as the run id, words the stopped outcome and clears the flag in a `finally` block. |
| `ask_alyf.bundle.js` | `handleSendClick` routes to `stopMessage`. `updateSendButton` switches the label between Send and Stop. |
| `ask_alyf.bundle.css` | The button stays clickable while loading. The dimming moves to `:disabled`. |

## One flag per run

The flag is keyed to the run, not to the conversation. The run is identified by the user message that started it, which is unique per run and already known to the browser, the job and the stored history.

Two runs that overlap on one conversation therefore carry different keys. Neither run reads or clears the flag of the other. A flag left behind by a run that already ended cannot reach a later run, because the later run has its own key. The job still clears its own flag in a `finally` block, and the TTL removes the rest.

A resume carries no run id and cannot be stopped. The browser waits on that call, so there is no spinner to escape from.

`is_stop_requested` reads the cache from the agent threads. A failed read and a missing flag give the same answer, which is to keep going. A flaky read can delay a stop to the next step. It cannot invent one.

## Tests

`bench --site <site> run-tests --app ask_alyf` passes, 140 unit tests and 16 integration tests.

New test `test_pressing_stop_ends_the_run_before_the_next_model_call`:

- With the flag set, the agent never reaches the model.
- A fresh saver reads the checkpoint back from the database.
- After the flag is cleared, the same agent runs as before.

New test `test_a_stopped_run_skips_the_rest_of_the_planned_tool_calls`: with the flag set, the tool wrapper returns a `ToolMessage` for the call, never runs the tool and logs no step.

`make_runtime` in `test_code_tools.py` now builds the real `ask_alyfRuntime` instead of a `SimpleNamespace` copy of it. The copy went stale whenever the dataclass got a field.

## Known limits

- A tool call that is already running finishes. The stop skips the calls that have not started.
- The `general-purpose` subagent comes from Deep Agents and carries no middleware. A delegation to it runs to its end.
- The button stays disabled in the short *Sending...* window, until the run reports its job. A stop needs a job to name.
