### PR TITLE
refactor: name the tool wrapper after what it does

### DIFF
--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -34,7 +34,7 @@ from ask_alyf.ask_alyf.toolset import (
 	OPERATION_INTERRUPT_KEY,
 	ask_alyfRuntime,
 	ask_alyfToolset,
-	clear_messages_on_tool_error,
+	in_private_frappe_context,
 	is_stop_requested,
 )
 
@@ -432,7 +432,7 @@ Mode awareness and behavior:
 				]
 			)
 
-		return [clear_messages_on_tool_error(fn) for fn in tool_defs]
+		return [in_private_frappe_context(fn) for fn in tool_defs]
 
 	def _build_subagents(self) -> list[SubAgent]:
 		# ``general-purpose`` is auto-added by Deep Agents; we only declare the
@@ -481,7 +481,7 @@ Mode awareness and behavior:
 					),
 					"system_prompt": DOCUMENT_PLANNER_INSTRUCTIONS,
 					"tools": [
-						clear_messages_on_tool_error(fn)
+						in_private_frappe_context(fn)
 						for fn in (
 							self.toolset.get_list,
 							self.toolset.get,

--- a/ask_alyf/ask_alyf/field_agent.py
+++ b/ask_alyf/ask_alyf/field_agent.py
@@ -8,7 +8,7 @@ import frappe
 
 from ask_alyf.ask_alyf import field_contexts, tools
 from ask_alyf.ask_alyf.agent import build_chat_model, build_stateless_agent
-from ask_alyf.ask_alyf.toolset import ask_alyfToolset, clear_messages_on_tool_error
+from ask_alyf.ask_alyf.toolset import ask_alyfToolset, in_private_frappe_context
 
 # Read-only tool method names exposed to the field agent.
 # Excludes: source_code_analyzer (unbounded latency in request thread),
@@ -137,7 +137,7 @@ def run_field_agent(
 	toolset = ask_alyfToolset(runtime=runtime, settings=settings)
 
 	tool_defs = [
-		clear_messages_on_tool_error(getattr(toolset, method_name)) for method_name in FIELD_AGENT_TOOLS
+		in_private_frappe_context(getattr(toolset, method_name)) for method_name in FIELD_AGENT_TOOLS
 	]
 
 	model = build_chat_model(settings, temperature=0.1)

--- a/ask_alyf/ask_alyf/test_checkpointer.py
+++ b/ask_alyf/ask_alyf/test_checkpointer.py
@@ -32,8 +32,8 @@ from ask_alyf.ask_alyf.toolset import (
 	OPERATION_INTERRUPT_KEY,
 	ask_alyfRuntime,
 	ask_alyfToolset,
-	clear_messages_on_tool_error,
 	clear_stop_request,
+	in_private_frappe_context,
 	is_stop_requested,
 	request_stop,
 )
@@ -252,7 +252,7 @@ class IntegrationTestFrappeCheckpointSaver(IntegrationTestCase):
 		arrives in a different process with a different saver.
 		"""
 		runtime = ask_alyfRuntime(conversation_name=THREAD, mode="Agent", request_context={})
-		tool = clear_messages_on_tool_error(ask_alyfToolset(runtime).set_value)
+		tool = in_private_frappe_context(ask_alyfToolset(runtime).set_value)
 		tool_call = {
 			"name": "set_value",
 			"args": {

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -32,8 +32,8 @@ from ask_alyf.ask_alyf.toolset import (
 	OPERATION_INTERRUPT_KEY,
 	ask_alyfRuntime,
 	ask_alyfToolset,
-	clear_messages_on_tool_error,
 	clear_running_steps,
+	in_private_frappe_context,
 	read_running_steps,
 )
 
@@ -821,7 +821,7 @@ class UnitTestCodeTools(UnitTestCase):
 				},
 			}
 
-		wrapped = clear_messages_on_tool_error(tool)
+		wrapped = in_private_frappe_context(tool)
 		with (
 			patch("ask_alyf.ask_alyf.toolset.frappe.init", side_effect=init) as init_mock,
 			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect) as connect_mock,
@@ -959,7 +959,7 @@ class UnitTestCodeTools(UnitTestCase):
 		"""
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
-		wrapped = clear_messages_on_tool_error(toolset.set_value)
+		wrapped = in_private_frappe_context(toolset.set_value)
 
 		operation = proposed_operation(
 			lambda: wrapped("ToDo", "TODO-0001", "status", "Closed", reason="Close it.")
@@ -971,7 +971,7 @@ class UnitTestCodeTools(UnitTestCase):
 	def test_a_confirmed_proposal_executes_and_returns_its_result(self):
 		runtime = self.make_runtime(mode="Agent")
 		toolset = ask_alyfToolset(runtime)
-		wrapped = clear_messages_on_tool_error(toolset.set_value)
+		wrapped = in_private_frappe_context(toolset.set_value)
 		call_id = proposed_operation(lambda: wrapped("ToDo", "TODO-0001", "status", "Closed"))["call_id"]
 		self.assertFalse(getattr(runtime, "backend_operation_committed", False))
 
@@ -1061,7 +1061,7 @@ class UnitTestCodeTools(UnitTestCase):
 				"message_log": list(frappe.local.message_log),
 			}
 
-		wrapped = clear_messages_on_tool_error(tool)
+		wrapped = in_private_frappe_context(tool)
 		contexts = [contextvars.copy_context(), contextvars.copy_context()]
 
 		try:
@@ -1108,7 +1108,7 @@ class UnitTestCodeTools(UnitTestCase):
 			self.assertFalse(set_admin_as_user)
 			frappe.local.db = private_db
 
-		wrapped = clear_messages_on_tool_error(lambda: "done")
+		wrapped = in_private_frappe_context(lambda: "done")
 		try:
 			with (
 				patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
@@ -1144,7 +1144,7 @@ class UnitTestCodeTools(UnitTestCase):
 		def tool():
 			raise ValueError("tool failed")
 
-		wrapped = clear_messages_on_tool_error(tool)
+		wrapped = in_private_frappe_context(tool)
 		with (
 			patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),
 			patch("ask_alyf.ask_alyf.toolset.frappe.destroy", side_effect=destroy),
@@ -1170,7 +1170,7 @@ class UnitTestCodeTools(UnitTestCase):
 			self.assertEqual((id(frappe.local.db), id(frappe.local.flags)), private_state)
 			return {"file_id": file_id}
 
-		wrapped = clear_messages_on_tool_error(fake_tool)
+		wrapped = in_private_frappe_context(fake_tool)
 		with patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect):
 			result = asyncio.run(wrapped("FILE-0001"))
 
@@ -1196,7 +1196,7 @@ class UnitTestCodeTools(UnitTestCase):
 			await asyncio.sleep(0)
 			raise RuntimeError("boom")
 
-		wrapped = clear_messages_on_tool_error(fake_tool)
+		wrapped = in_private_frappe_context(fake_tool)
 		try:
 			with (
 				patch("ask_alyf.ask_alyf.toolset.frappe.connect", side_effect=connect),

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -1,3 +1,28 @@
+"""The tools the agent calls, and the Frappe context each call runs in.
+
+Two invariants hold for every tool call, and most of the surrounding
+machinery exists to keep them:
+
+* **Each tool call owns its Frappe context and database connection.**
+  LangGraph fans tasks out over a background executor with the parent
+  context *copied*, and `frappe.local` is contextvar-backed — so worker
+  threads would otherwise share one pymysql connection, which is not safe
+  for concurrent use (`Packet sequence number wrong`). Hence the empty
+  `contextvars.Context()` plus a private `frappe.init`/`connect` per call
+  (see `in_private_frappe_context`).
+
+* **Each tool call is therefore its own transaction.** A private connection
+  cannot join the job's transaction, so a tool commits when it returns and
+  rolls back when it raises. That also matches how an agent turn works: the
+  model is told a write succeeded and reasons on from there, and the turn
+  can pause on `interrupt()` and resume in a later request. What the model
+  was told stays true.
+
+The cost of the second invariant is paid in `agent.py` — the resume
+savepoint, `backend_operation_committed`, and dropping a thread whose write
+landed but whose follow-up died.
+"""
+
 import asyncio
 import contextlib
 import contextvars
@@ -1251,7 +1276,7 @@ def _private_frappe_context(caller: _CallerFrappeContext):
 			frappe.destroy()
 
 
-def clear_messages_on_tool_error(func):
+def in_private_frappe_context(func):
 	"""Run each tool call in a fresh Frappe context and DB connection."""
 
 	if inspect.iscoroutinefunction(func):


### PR DESCRIPTION
## Why

`clear_messages_on_tool_error` has not been about messages since 4e186e5. Since then it gives every tool call its own Frappe context and database connection; discarding queued messages is a detail of its error path. The stale name is the main reason `toolset.py` reads as accidental complexity rather than as a deliberate answer to two constraints.

Those constraints were only written down in commit messages, so they are now a module docstring:

- **One context and connection per tool call.** LangGraph fans tasks out over a background executor with the parent context *copied*, and `frappe.local` is contextvar-backed — so worker threads would otherwise share one pymysql connection, which is not safe for concurrent use.
- **Therefore one transaction per tool call.** A private connection cannot join the job's transaction. This also matches how an agent turn works: the model is told a write succeeded and reasons on from there, and the turn can pause on `interrupt()` and resume in a later request.

## What changed

- Renamed `clear_messages_on_tool_error` → `in_private_frappe_context` (17 call sites, mechanical).
- Added the module docstring to `toolset.py`.

No behaviour change.

## Test

`bench --site test-site-dev run-tests --app ask_alyf` — 141 unit + 17 integration tests pass.