### PR TITLE
feat: add conversation deletion functionality

### DIFF
--- a/ask_alyf/api.py
+++ b/ask_alyf/api.py
@@ -11,6 +11,7 @@ from ask_alyf.ask_alyf.api import (
 	reject_pending_operation,
 	send_message,
 	start_new_conversation,
+	delete_conversation,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
 	"reject_pending_operation",
 	"send_message",
 	"start_new_conversation",
+	"delete_conversation",
 ]

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -99,6 +99,7 @@ def get_ask_alyf_boot_payload() -> dict:
 	agent_mode_enabled = False
 	field_agent_enabled = False
 	file_upload_enabled = False
+	conversation_deletion_enabled = False
 	support_phone_number = ""
 	support_phone_uri = ""
 
@@ -107,6 +108,7 @@ def get_ask_alyf_boot_payload() -> dict:
 		agent_mode_enabled = bool(settings.allow_agent_mode)
 		field_agent_enabled = bool(settings.allow_field_agent)
 		file_upload_enabled = bool(settings.allow_file_upload)
+		conversation_deletion_enabled = bool(settings.allow_conversation_deletion)
 		api_key = (settings.get_password("api_key", raise_exception=False) or "").strip()
 		configured = bool(api_key and (settings.model or "").strip())
 		support_phone_number = (settings.support_phone_number or "").strip()
@@ -120,6 +122,7 @@ def get_ask_alyf_boot_payload() -> dict:
 		"agent_mode_enabled": agent_mode_enabled,
 		"field_agent_enabled": field_agent_enabled,
 		"file_upload_enabled": file_upload_enabled,
+		"conversation_deletion_enabled": conversation_deletion_enabled,
 		"support_phone_number": support_phone_number,
 		"support_phone_uri": support_phone_uri,
 		"default_mode": MODE_ASK,
@@ -412,6 +415,20 @@ def _has_running_job(messages: list[dict]) -> bool:
 		if job_id:
 			return get_job_status(job_id) in PENDING_JOB_STATUSES
 	return False
+
+
+@frappe.whitelist(methods=["POST"])
+def delete_conversation(conversation: str) -> dict:
+	if not can_access_ask_alyf():
+		frappe.throw(_("You do not have access to Ask ALYF."))
+
+	if not get_settings().allow_conversation_deletion:
+		frappe.throw(_("Conversation deletion is not allowed."))
+
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc.check_permission("delete")
+	doc.delete()
+	return {"success": True}
 
 
 @frappe.whitelist(methods=["POST"])

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
@@ -16,6 +16,7 @@
   "allow_code_search",
   "allow_file_upload",
   "allow_field_agent",
+  "allow_conversation_deletion",
   "chat_provider_tab",
   "llm_provider",
   "base_url",
@@ -106,6 +107,12 @@
    "fieldname": "allow_file_upload",
    "fieldtype": "Check",
    "label": "Allow File Upload"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_conversation_deletion",
+   "fieldtype": "Check",
+   "label": "Allow Conversation Deletion"
   },
   {
    "fieldname": "chat_provider_tab",

--- a/ask_alyf/public/css/ask_alyf.bundle.css
+++ b/ask_alyf/public/css/ask_alyf.bundle.css
@@ -444,17 +444,31 @@
 
 .ask_alyf-history-item {
 	width: 100%;
-	text-align: left;
 	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 0.2rem;
+	flex-direction: row;
+	align-items: stretch;
+	gap: 0.35rem;
 	transition: transform 0.16s cubic-bezier(0.25, 1, 0.5, 1),
 		box-shadow 0.2s ease;
 }
 
 .ask_alyf-history-item:hover {
 	transform: translateY(-1px);
+}
+
+.ask_alyf-history-item-main {
+	flex: 1 1 auto;
+	min-width: 0;
+	text-align: left;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.2rem;
+}
+
+.ask_alyf-history-item-delete {
+	flex: 0 0 auto;
+	align-self: stretch;
 }
 
 .ask_alyf-history-item-title {

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -1224,6 +1224,22 @@ import "./field_agent";
 			this.openConversation(conversationName);
 		}
 
+		onHistoryConversationDeleteClick(event, conversationName) {
+			event.preventDefault();
+			event.stopPropagation();
+			if (!conversationName || !this.isConversationDeletionEnabled()) {
+				return;
+			}
+
+			frappe.confirm(__("Delete this conversation?"), async () => {
+				try {
+					await this.deleteConversation(conversationName);
+				} catch (error) {
+					frappe.msgprint(error.message || __("Failed to delete conversation."));
+				}
+			});
+		}
+
 		onModeOptionClick(event) {
 			const option = event.currentTarget;
 			const selectedMode = option?.dataset?.mode;
@@ -1262,6 +1278,10 @@ import "./field_agent";
 
 		isFileUploadEnabled() {
 			return Boolean(frappe?.boot?.ask_alyf?.file_upload_enabled);
+		}
+
+		isConversationDeletionEnabled() {
+			return Boolean(frappe?.boot?.ask_alyf?.conversation_deletion_enabled);
 		}
 
 		syncFileUploadButton() {
@@ -1643,15 +1663,20 @@ import "./field_agent";
 				return;
 			}
 
+			const deletionEnabled = this.isConversationDeletionEnabled();
+
 			recentConversations.forEach((conversation) => {
-				const itemEl = document.createElement("button");
-				itemEl.type = "button";
-				itemEl.className = "ask_alyf-history-item btn btn-secondary btn-sm";
-				itemEl.dataset.conversation = conversation.name;
+				const itemEl = document.createElement("div");
+				itemEl.className = "ask_alyf-history-item";
+
+				const mainEl = document.createElement("button");
+				mainEl.type = "button";
+				mainEl.className = "ask_alyf-history-item-main btn btn-secondary btn-sm";
+				mainEl.dataset.conversation = conversation.name;
 
 				if (conversation.name === currentName) {
-					itemEl.classList.remove("btn-secondary");
-					itemEl.classList.add("btn-primary");
+					mainEl.classList.remove("btn-secondary");
+					mainEl.classList.add("btn-primary");
 				}
 
 				const titleEl = document.createElement("div");
@@ -1663,9 +1688,25 @@ import "./field_agent";
 				const timestampLabel = this.formatConversationTimestamp(conversation);
 				metaEl.textContent = timestampLabel || "";
 
-				itemEl.appendChild(titleEl);
-				itemEl.appendChild(metaEl);
-				itemEl.addEventListener("click", (event) => this.onHistoryConversationClick(event));
+				mainEl.appendChild(titleEl);
+				mainEl.appendChild(metaEl);
+				mainEl.addEventListener("click", (event) => this.onHistoryConversationClick(event));
+				itemEl.appendChild(mainEl);
+
+				if (deletionEnabled) {
+					const deleteEl = document.createElement("button");
+					deleteEl.type = "button";
+					deleteEl.className =
+						"ask_alyf-history-item-delete ask_alyf-icon-button btn btn-secondary btn-sm";
+					deleteEl.title = __("Delete conversation");
+					deleteEl.setAttribute("aria-label", __("Delete conversation"));
+					deleteEl.innerHTML = getIcon("trash", "sm", "", true);
+					deleteEl.addEventListener("click", (event) =>
+						this.onHistoryConversationDeleteClick(event, conversation.name),
+					);
+					itemEl.appendChild(deleteEl);
+				}
+
 				this.historyListEl.appendChild(itemEl);
 			});
 		}
@@ -2083,6 +2124,30 @@ import "./field_agent";
 			this.setLoading(false);
 			this.refreshConversationList();
 			this.setStatus("");
+		}
+
+		async deleteConversation(conversationName) {
+			if (!this.isConversationDeletionEnabled()) {
+				return;
+			}
+
+			const name = (conversationName || this.state.conversation?.name || "").toString();
+			if (!name) {
+				return;
+			}
+
+			await frappe.call({
+				method: "ask_alyf.api.delete_conversation",
+				type: "POST",
+				args: { conversation: name },
+			});
+
+			if (name === this.state.conversation?.name) {
+				await this.startNewConversation();
+				return;
+			}
+
+			this.refreshConversationList();
 		}
 
 		isFrontendAction(operation) {


### PR DESCRIPTION
- Implemented the `delete_conversation` API method to allow users to delete conversations.
- Updated settings to include `allow_conversation_deletion` option.
- Enhanced frontend to support conversation deletion with confirmation prompts and UI updates.
- Adjusted CSS for conversation history items to accommodate new delete button functionality.

Closes #14 