### PR TITLE
feat: add conversation deletion functionality

### DIFF
--- a/ask_alyf/api.py
+++ b/ask_alyf/api.py
@@ -4,6 +4,7 @@ from ask_alyf.ask_alyf.api import (
 	can_access_ask_alyf,
 	can_use_agent_mode,
 	confirm_pending_operation,
+	delete_conversation,
 	frontend_action_result,
 	get_ask_alyf_boot_payload,
 	list_conversations,
@@ -11,7 +12,6 @@ from ask_alyf.ask_alyf.api import (
 	reject_pending_operation,
 	send_message,
 	start_new_conversation,
-	delete_conversation,
 )
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
 	"can_access_ask_alyf",
 	"can_use_agent_mode",
 	"confirm_pending_operation",
+	"delete_conversation",
 	"frontend_action_result",
 	"get_ask_alyf_boot_payload",
 	"list_conversations",
@@ -27,5 +28,4 @@ __all__ = [
 	"reject_pending_operation",
 	"send_message",
 	"start_new_conversation",
-	"delete_conversation",
 ]

--- a/ask_alyf/api.py
+++ b/ask_alyf/api.py
@@ -11,6 +11,7 @@ from ask_alyf.ask_alyf.api import (
 	reject_pending_operation,
 	send_message,
 	start_new_conversation,
+	delete_conversation,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
 	"reject_pending_operation",
 	"send_message",
 	"start_new_conversation",
+	"delete_conversation",
 ]

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -99,6 +99,7 @@ def get_ask_alyf_boot_payload() -> dict:
 	agent_mode_enabled = False
 	field_agent_enabled = False
 	file_upload_enabled = False
+	conversation_deletion_enabled = False
 	support_phone_number = ""
 	support_phone_uri = ""
 
@@ -107,6 +108,7 @@ def get_ask_alyf_boot_payload() -> dict:
 		agent_mode_enabled = bool(settings.allow_agent_mode)
 		field_agent_enabled = bool(settings.allow_field_agent)
 		file_upload_enabled = bool(settings.allow_file_upload)
+		conversation_deletion_enabled = bool(settings.allow_conversation_deletion)
 		api_key = (settings.get_password("api_key", raise_exception=False) or "").strip()
 		configured = bool(api_key and (settings.model or "").strip())
 		support_phone_number = (settings.support_phone_number or "").strip()
@@ -120,6 +122,7 @@ def get_ask_alyf_boot_payload() -> dict:
 		"agent_mode_enabled": agent_mode_enabled,
 		"field_agent_enabled": field_agent_enabled,
 		"file_upload_enabled": file_upload_enabled,
+		"conversation_deletion_enabled": conversation_deletion_enabled,
 		"support_phone_number": support_phone_number,
 		"support_phone_uri": support_phone_uri,
 		"default_mode": MODE_ASK,
@@ -412,6 +415,20 @@ def _has_running_job(messages: list[dict]) -> bool:
 		if job_id:
 			return get_job_status(job_id) in PENDING_JOB_STATUSES
 	return False
+
+
+@frappe.whitelist(methods=["POST"])
+def delete_conversation(conversation: str) -> dict:
+	if not can_access_ask_alyf():
+		frappe.throw(_("You do not have access to Ask ALYF."))
+
+	if not get_settings().allow_conversation_deletion:
+		frappe.throw(_("Conversation deletion is not allowed."))
+
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc.check_permission("delete")
+	doc.delete()
+	return {"success": True}
 
 
 @frappe.whitelist(methods=["POST"])

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -13,6 +13,7 @@ from rq.job import JobStatus
 
 from ask_alyf.ask_alyf import field_agent
 from ask_alyf.ask_alyf.agent import resume_operation, run_message
+from ask_alyf.ask_alyf.checkpointer import delete_checkpoints
 from ask_alyf.ask_alyf.tools import (
 	OPERATION_KIND_BACKEND,
 	OPERATION_KIND_FRONTEND,
@@ -646,6 +647,7 @@ def process_message_job(
 
 	if not frappe.db.exists("Ask ALYF Conversation", conversation_name):
 		clear_running_steps(conversation_name)
+		delete_checkpoints([conversation_name])
 		return
 
 	file_message = None

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -425,8 +425,13 @@ def delete_conversation(conversation: str) -> dict:
 	if not get_settings().allow_conversation_deletion:
 		frappe.throw(_("Conversation deletion is not allowed."))
 
-	doc = frappe.get_doc("Ask ALYF Conversation", conversation)
+	doc = frappe.get_doc("Ask ALYF Conversation", conversation, for_update=True)
 	doc.check_permission("delete")
+	if _has_running_job(get_messages(doc)):
+		frappe.throw(
+			_("Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting.")
+		)
+
 	doc.delete()
 	return {"success": True}
 
@@ -636,6 +641,10 @@ def process_message_job(
 		tool_calls = None
 	finally:
 		clear_stop_request(user_message_id or "")
+
+	if not frappe.db.exists("Ask ALYF Conversation", conversation_name):
+		clear_running_steps(conversation_name)
+		return
 
 	file_message = None
 	if isinstance(attached_files, list) and attached_files:

--- a/ask_alyf/ask_alyf/api.py
+++ b/ask_alyf/ask_alyf/api.py
@@ -429,7 +429,9 @@ def delete_conversation(conversation: str) -> dict:
 	doc.check_permission("delete")
 	if _has_running_job(get_messages(doc)):
 		frappe.throw(
-			_("Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting.")
+			_(
+				"Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
+			)
 		)
 
 	doc.delete()

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -121,7 +121,7 @@ class UnitTestAskALYFConversation(UnitTestCase):
 			return {"response": "Done", "pending_operations": []}
 
 		with patch("ask_alyf.ask_alyf.api.run_message", side_effect=delete_conversation_mid_run):
-			with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime"):
+			with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime") as publish:
 				api.process_message_job(
 					conversation_name=conversation.name,
 					message="Open Sales Invoice list",
@@ -130,7 +130,7 @@ class UnitTestAskALYFConversation(UnitTestCase):
 					user_message_id=user_message["id"],
 				)
 
-		self.assertFalse(frappe.db.exists("Ask ALYF Conversation", conversation.name))
+		self.assertNotIn("ask_alyf_response_complete", [call.args[0] for call in publish.call_args_list])
 
 	def test_get_message_job_status_maps_rq_terminal_states(self):
 		job_id = "job-123"

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_conversation/test_ask_alyf_conversation.py
@@ -78,6 +78,60 @@ class UnitTestAskALYFConversation(UnitTestCase):
 
 		enqueue_job.assert_called_once()
 
+	def test_delete_conversation_refuses_while_job_is_running(self):
+		pending = api.make_message("user", "First", **{api.BACKGROUND_JOB_ID_KEY: "job-1"})
+		conversation = self.make_conversation(messages=[pending])
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch(
+				"ask_alyf.ask_alyf.api.get_settings",
+				return_value=SimpleNamespace(allow_conversation_deletion=True),
+			),
+			patch("ask_alyf.ask_alyf.api.get_job_status", return_value=JobStatus.STARTED),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				api.delete_conversation(conversation=conversation.name)
+
+		self.assertTrue(frappe.db.exists("Ask ALYF Conversation", conversation.name))
+
+	def test_delete_conversation_succeeds_when_idle(self):
+		conversation = self.make_conversation(
+			messages=[api.make_message("user", "Hi"), api.make_message("assistant", "Hello")]
+		)
+
+		with (
+			patch("ask_alyf.ask_alyf.api.can_access_ask_alyf", return_value=True),
+			patch(
+				"ask_alyf.ask_alyf.api.get_settings",
+				return_value=SimpleNamespace(allow_conversation_deletion=True),
+			),
+		):
+			response = api.delete_conversation(conversation=conversation.name)
+
+		self.assertEqual(response, {"success": True})
+		self.assertFalse(frappe.db.exists("Ask ALYF Conversation", conversation.name))
+
+	def test_process_message_job_skips_save_when_conversation_was_deleted(self):
+		user_message = api.make_message("user", "Open Sales Invoice list", mode=api.MODE_ASK)
+		conversation = self.make_conversation(messages=[user_message])
+
+		def delete_conversation_mid_run(**kwargs):
+			frappe.delete_doc("Ask ALYF Conversation", conversation.name, force=True)
+			return {"response": "Done", "pending_operations": []}
+
+		with patch("ask_alyf.ask_alyf.api.run_message", side_effect=delete_conversation_mid_run):
+			with patch("ask_alyf.ask_alyf.api.frappe.publish_realtime"):
+				api.process_message_job(
+					conversation_name=conversation.name,
+					message="Open Sales Invoice list",
+					mode=api.MODE_ASK,
+					context_data={},
+					user_message_id=user_message["id"],
+				)
+
+		self.assertFalse(frappe.db.exists("Ask ALYF Conversation", conversation.name))
+
 	def test_get_message_job_status_maps_rq_terminal_states(self):
 		job_id = "job-123"
 		user_message = api.make_message(

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
@@ -185,7 +185,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-26 02:47:09.080302",
+ "modified": "2026-09-01 15:45:13.725210",
  "modified_by": "Administrator",
  "module": "Ask ALYF",
  "name": "Ask ALYF Settings",

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
@@ -16,6 +16,7 @@
   "allow_code_search",
   "allow_file_upload",
   "allow_field_agent",
+  "allow_conversation_deletion",
   "chat_provider_tab",
   "llm_provider",
   "base_url",
@@ -106,6 +107,12 @@
    "fieldname": "allow_file_upload",
    "fieldtype": "Check",
    "label": "Allow File Upload"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_conversation_deletion",
+   "fieldtype": "Check",
+   "label": "Allow Conversation Deletion"
   },
   {
    "fieldname": "chat_provider_tab",

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
@@ -62,8 +62,11 @@ class AskALYFSettings(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from ask_alyf.ask_alyf.doctype.ask_alyf_excluded_doctype.ask_alyf_excluded_doctype import AskALYFExcludedDocType
 		from frappe.types import DF
+
+		from ask_alyf.ask_alyf.doctype.ask_alyf_excluded_doctype.ask_alyf_excluded_doctype import (
+			AskALYFExcludedDocType,
+		)
 
 		allow_agent_mode: DF.Check
 		allow_code_search: DF.Check

--- a/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
+++ b/ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.py
@@ -62,14 +62,12 @@ class AskALYFSettings(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from ask_alyf.ask_alyf.doctype.ask_alyf_excluded_doctype.ask_alyf_excluded_doctype import AskALYFExcludedDocType
 		from frappe.types import DF
-
-		from ask_alyf.ask_alyf.doctype.ask_alyf_excluded_doctype.ask_alyf_excluded_doctype import (
-			AskALYFExcludedDocType,
-		)
 
 		allow_agent_mode: DF.Check
 		allow_code_search: DF.Check
+		allow_conversation_deletion: DF.Check
 		allow_field_agent: DF.Check
 		allow_file_upload: DF.Check
 		api_key: DF.Password | None

--- a/ask_alyf/locale/ar.po
+++ b/ask_alyf/locale/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: ar\n"
@@ -129,7 +129,7 @@ msgstr "و{0} أخرى."
 msgid "App '{0}' is not installed."
 msgstr "التطبيق '{0}' غير مثبت."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "جارٍ تطبيق الإجراء..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF هو ذكاء اصطناعي ويمكن أن يرتكب أخط�
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "لا يزال Ask ALYF يعمل على رسالة في هذه المحادثة. أوقفه أو انتظر حتى ينتهي قبل الحذف."
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "تم إلغاء عرض المخطط: {0}."
 msgid "Cancelled the pending operation: {0}."
 msgstr "تم إلغاء العملية المعلقة: {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "معاينة التغييرات"
 
@@ -426,13 +426,13 @@ msgstr "قم بتكوين مفتاح API في إعدادات Ask ALYF قبل إ�
 msgid "Confirm all"
 msgstr "تأكيد الكل"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "جارٍ تأكيد الإجراء..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "لا يُسمح بحذف المحادثات."
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "تعذّر إكمال العملية: {0}."
 msgid "Could not display chart."
 msgstr "تعذر عرض الرسم البياني."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "تعذر تحميل الرسم البياني."
 
@@ -467,7 +467,7 @@ msgstr "تعذر استخراج المحتوى المرئي من الملف."
 msgid "Could not generate content."
 msgstr "تعذر إنشاء المحتوى."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "تعذر عرض الخريطة."
 
@@ -505,12 +505,12 @@ msgstr "تم إنشاء {0} من أصل {1} من سجلات {2}."
 msgid "Creating several {0} records"
 msgstr "إنشاء عدة سجلات {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "المستند الحالي هو {0}، المتوقع {1}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "الاستمارة الحالية هي {0}، المتوقع {1}."
@@ -524,8 +524,8 @@ msgstr "يجب أن تكون قيم مجموعة البيانات رقمية."
 msgid "Dataset values must match labels length."
 msgstr "يجب أن تتطابق قيم مجموعة البيانات مع طول التسميات."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "حذف المحادثة"
 
@@ -589,7 +589,7 @@ msgstr "لم يُرجع استخراج المستند أي محتوى."
 msgid "Document name is required."
 msgstr "اسم المستند مطلوب."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "تحميل الخريطة بصيغة SVG"
 
@@ -647,7 +647,7 @@ msgstr "الصفوف الفاشلة: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "فشل إرفاق الملف بالمحادثة."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "فشل تأكيد العملية المعلقة."
 
@@ -655,23 +655,23 @@ msgstr "فشل تأكيد العملية المعلقة."
 msgid "Failed to delete conversation."
 msgstr "فشل حذف المحادثة."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "فشل تنفيذ إجراء الواجهة الأمامية."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "فشل فتح المحادثة."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "فشل رفض العملية المعلقة."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "فشل إرسال الرسالة."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "فشل إيقاف التشغيل."
 
@@ -693,8 +693,8 @@ msgstr "وكيل الحقل غير مفعّل."
 msgid "Field updated."
 msgstr "تم تحديث الحقل."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "الحقل {0} غير موجود في هذه الاستمارة."
@@ -765,7 +765,7 @@ msgstr "يتطلب إجراء الواجهة الأمامية 'set_route' قائ
 msgid "Frontend action failed: {0}"
 msgstr "فشل إجراء الواجهة الأمامية: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "إجراء الواجهة الأمامية يفتقر إلى معرّف اتصال (Call ID)."
 
@@ -838,7 +838,7 @@ msgstr "لقد قمت بإعداد العملية. يُرجى المراجعة �
 msgid "Invalid action payload."
 msgstr "حمولة إجراء غير صالحة."
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "بيانات الرسم البياني غير صالحة."
 
@@ -882,7 +882,7 @@ msgstr "آخر رسالة في"
 msgid "Line offset {0} exceeds file length"
 msgstr "إزاحة السطر {0} تتجاوز طول الملف"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "جارٍ تحميل المحادثة..."
 
@@ -958,7 +958,7 @@ msgstr "لا توجد محادثات بعد."
 msgid "No documentation URL was found for app '{0}'."
 msgstr "لم يتم العثور على URL التوثيق للتطبيق '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "لا توجد استمارة مفتوحة حاليًا."
 
@@ -1100,7 +1100,7 @@ msgstr "يجب أن يبدأ المسار باسم تطبيق مثبت."
 msgid "Pending Operation JSON"
 msgstr "JSON العملية المعلقة"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "عملية معلقة"
 
@@ -1240,7 +1240,7 @@ msgstr "السبب: {0}"
 msgid "Reasoning Effort"
 msgstr "جهد الاستدلال"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "السجلات المراد إنشاؤها ({0})"
@@ -1320,7 +1320,7 @@ msgstr "يحتاج إجراء التمرير إلى تصحيح."
 msgid "Scroll to field {0}"
 msgstr "التمرير إلى الحقل {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "التمرير إلى الحقول غير متاح في هذه الاستمارة."
 
@@ -1336,7 +1336,7 @@ msgstr "جارٍ البحث في شفرة المصدر"
 msgid "Selling"
 msgstr "المبيعات"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "جارٍ الإرسال..."
 
@@ -1451,7 +1451,7 @@ msgstr "لا يزال قيد الإنشاء..."
 msgid "Stock"
 msgstr "المخزون"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "إيقاف هذا التشغيل"
 
@@ -1459,7 +1459,7 @@ msgstr "إيقاف هذا التشغيل"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "تم الإيقاف. أرسل رسالة للمتابعة من هنا."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "جارٍ الإيقاف..."
 
@@ -1613,7 +1613,7 @@ msgstr "نوع الملف '{0}' غير مدعوم. الأنواع المدعوم
 msgid "Unsupported frontend action '{0}'."
 msgstr "إجراء واجهة أمامية غير مدعوم '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "إجراء واجهة أمامية غير مدعوم: {0}"
@@ -1694,12 +1694,12 @@ msgstr "مزود Vision"
 msgid "Voice input"
 msgstr "إدخال صوتي"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "لغة الإدخال الصوتي: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "في انتظار الرد..."
 
@@ -1761,7 +1761,7 @@ msgstr "ليس لديك صلاحية الوصول إلى Ask ALYF."
 msgid "You do not have read permission on {0}."
 msgstr "ليس لديك صلاحية القراءة على {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "متصفحك لا يدعم الإدخال الصوتي."
 
@@ -1830,7 +1830,7 @@ msgstr "مرتفع جدًا"
 msgid "{0} '{1}' was not found."
 msgstr "لم يتم العثور على {0} ‘{1}’."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} صفوف"

--- a/ask_alyf/locale/ar.po
+++ b/ask_alyf/locale/ar.po
@@ -1586,6 +1586,11 @@ msgstr "{0} عنصر"
 msgid "{0} rows"
 msgstr "{0} صفوف"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "حذف المحادثة"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "هل تريد حذف هذه المحادثة؟"

--- a/ask_alyf/locale/ar.po
+++ b/ask_alyf/locale/ar.po
@@ -1580,3 +1580,11 @@ msgstr "{0} عنصر"
 msgid "{0} rows"
 msgstr "{0} صفوف"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "هل تريد حذف هذه المحادثة؟"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "فشل حذف المحادثة."
+

--- a/ask_alyf/locale/ar.po
+++ b/ask_alyf/locale/ar.po
@@ -87,6 +87,12 @@ msgstr "السماح بوضع الوكيل"
 msgid "Allow Code Search"
 msgstr "السماح بالبحث في الشيفرة"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "السماح بحذف المحادثة"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/bn.po
+++ b/ask_alyf/locale/bn.po
@@ -1586,6 +1586,11 @@ msgstr "{0} আইটেম"
 msgid "{0} rows"
 msgstr "{0} সারি"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "কথোপকথন মুছুন"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "এই কথোপকথন মুছে ফেলবেন?"

--- a/ask_alyf/locale/bn.po
+++ b/ask_alyf/locale/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: bn\n"
@@ -129,7 +129,7 @@ msgstr "এবং আরও {0} টি।"
 msgid "App '{0}' is not installed."
 msgstr "অ্যাপ '{0}' ইনস্টল করা নেই।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "অ্যাকশন প্রয়োগ করা হচ্ছে..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF একটি AI এবং সংখ্যা এবং ব্�
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF এই কথোপকথনে একটি বার্তা নিয়ে এখনও কাজ করছে। মুছে ফেলার আগে এটি থামান অথবা শেষ হওয়ার জন্য অপেক্ষা করুন।"
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "চার্ট দেখানো বাতিল করা হয়�
 msgid "Cancelled the pending operation: {0}."
 msgstr "মুলতুবি অপারেশন বাতিল করা হয়েছে: {0}।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "পরিবর্তনের প্রিভিউ"
 
@@ -426,13 +426,13 @@ msgstr "বার্তা পাঠানোর আগে Ask ALYF সেটি
 msgid "Confirm all"
 msgstr "সব নিশ্চিত করুন"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "অ্যাকশন নিশ্চিত করা হচ্ছে..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "কথোপকথন মুছে ফেলার অনুমতি নেই।"
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "অপারেশন সম্পন্ন করা যায়নি
 msgid "Could not display chart."
 msgstr "চার্ট প্রদর্শন করা যায়নি।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "চার্ট ডাউনলোড করা যায়নি।"
 
@@ -467,7 +467,7 @@ msgstr "ফাইল থেকে ভিজ্যুয়াল কন্টে
 msgid "Could not generate content."
 msgstr "কন্টেন্ট তৈরি করা যায়নি।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "চার্ট রেন্ডার করা যায়নি।"
 
@@ -505,12 +505,12 @@ msgstr "{1} টির মধ্যে {0} টি {2} রেকর্ড তৈ�
 msgid "Creating several {0} records"
 msgstr "একাধিক {0} রেকর্ড তৈরি করা হচ্ছে"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "বর্তমান নথি হল {0}, প্রত্যাশিত {1}।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "বর্তমান ফর্ম হল {0}, প্রত্যাশিত {1}।"
@@ -524,8 +524,8 @@ msgstr "ডেটাসেটের মান অবশ্যই সংখ্য
 msgid "Dataset values must match labels length."
 msgstr "ডেটাসেটের মানগুলি অবশ্যই লেবেলের দৈর্ঘ্যের সাথে মিলতে হবে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "কথোপকথন মুছুন"
 
@@ -589,7 +589,7 @@ msgstr "ডকুমেন্ট নিষ্কাশন কোনও বিষ
 msgid "Document name is required."
 msgstr "ডকুমেন্টের নাম প্রয়োজন।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "চার্ট SVG হিসাবে ডাউনলোড করুন"
 
@@ -647,7 +647,7 @@ msgstr "ব্যর্থ সারি: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "কথোপকথনে ফাইল সংযুক্ত করতে ব্যর্থ।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "মুলতুবি অপারেশন নিশ্চিত করতে ব্যর্থ হয়েছে।"
 
@@ -655,23 +655,23 @@ msgstr "মুলতুবি অপারেশন নিশ্চিত কর
 msgid "Failed to delete conversation."
 msgstr "কথোপকথন মুছতে ব্যর্থ হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "ফ্রন্টএন্ড অ্যাকশন কার্যকর করতে ব্যর্থ হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "কথোপকথন খুলতে ব্যর্থ হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "মুলতুবি অপারেশন প্রত্যাখ্যান করতে ব্যর্থ হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "বার্তা পাঠাতে ব্যর্থ হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "রান বন্ধ করা যায়নি।"
 
@@ -693,8 +693,8 @@ msgstr "ফিল্ড Agent সক্ষম নয়।"
 msgid "Field updated."
 msgstr "ফিল্ড আপডেট করা হয়েছে।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "এই ফর্মে {0} ফিল্ড বিদ্যমান নেই।"
@@ -765,7 +765,7 @@ msgstr "ফ্রন্টএন্ড অ্যাকশন 'set_route'-এর 
 msgid "Frontend action failed: {0}"
 msgstr "ফ্রন্টএন্ড অ্যাকশন ব্যর্থ হয়েছে: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "ফ্রন্টএন্ড অ্যাকশনে একটি কল ID অনুপস্থিত।"
 
@@ -838,7 +838,7 @@ msgstr "আমি অপারেশনটি প্রস্তুত করে
 msgid "Invalid action payload."
 msgstr "অবৈধ অ্যাকশন পেলোড।"
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "অবৈধ চার্ট ডেটা।"
 
@@ -882,7 +882,7 @@ msgstr "সর্বশেষ বার্তা প্রাপ্তির স
 msgid "Line offset {0} exceeds file length"
 msgstr "লাইন অফসেট {0} ফাইলের দৈর্ঘ্য অতিক্রম করেছে"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "কথোপকথন লোড হচ্ছে..."
 
@@ -958,7 +958,7 @@ msgstr "এখনও কোনো কথোপকথন নেই।"
 msgid "No documentation URL was found for app '{0}'."
 msgstr "'{0}' অ্যাপের জন্য কোনো ডকুমেন্টেশন URL পাওয়া যায়নি।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "বর্তমানে কোনো ফর্ম খোলা নেই।"
 
@@ -1100,7 +1100,7 @@ msgstr "Path অবশ্যই একটি ইনস্টল করা অ্
 msgid "Pending Operation JSON"
 msgstr "Pending Operation JSON"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "মুলতুবি কার্যক্রম"
 
@@ -1240,7 +1240,7 @@ msgstr "কারণ: {0}"
 msgid "Reasoning Effort"
 msgstr "রিজনিং প্রচেষ্টা"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "তৈরি করার রেকর্ড ({0})"
@@ -1320,7 +1320,7 @@ msgstr "স্ক্রল অ্যাকশন সংশোধন প্রয
 msgid "Scroll to field {0}"
 msgstr "{0} ফিল্ডে স্ক্রল করুন"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "এই ফর্মে ফিল্ডে স্ক্রল করা উপলব্ধ নয়।"
 
@@ -1336,7 +1336,7 @@ msgstr "সোর্স কোডে অনুসন্ধান করা হ�
 msgid "Selling"
 msgstr "বিক্রয়"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "পাঠানো হচ্ছে..."
 
@@ -1451,7 +1451,7 @@ msgstr "এখনও তৈরি হচ্ছে..."
 msgid "Stock"
 msgstr "স্টক"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "এই রানটি থামান"
 
@@ -1459,7 +1459,7 @@ msgstr "এই রানটি থামান"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "থামানো হয়েছে। এখান থেকে চালিয়ে যেতে একটি বার্তা পাঠান।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "থামানো হচ্ছে..."
 
@@ -1613,7 +1613,7 @@ msgstr "অসমর্থিত ফাইল প্রকার '{0}'। সম
 msgid "Unsupported frontend action '{0}'."
 msgstr "অসমর্থিত ফ্রন্টএন্ড অ্যাকশন '{0}'।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "অসমর্থিত ফ্রন্টএন্ড অ্যাকশন: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Vision প্রদানকারী"
 msgid "Voice input"
 msgstr "ভয়েস ইনপুট"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "ভয়েস ইনপুট ভাষা: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "প্রতিক্রিয়ার জন্য অপেক্ষা করা হচ্ছে..."
 
@@ -1761,7 +1761,7 @@ msgstr "Ask ALYF-এ আপনার অ্যাক্সেস নেই।"
 msgid "You do not have read permission on {0}."
 msgstr "{0}-এ আপনার পড়ার অনুমতি নেই।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "আপনার ব্রাউজার ভয়েস ইনপুট সমর্থন করে না।"
 
@@ -1830,7 +1830,7 @@ msgstr "অতি উচ্চ"
 msgid "{0} '{1}' was not found."
 msgstr "{0} '{1}' পাওয়া যায়নি।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} সারি"

--- a/ask_alyf/locale/bn.po
+++ b/ask_alyf/locale/bn.po
@@ -1580,3 +1580,11 @@ msgstr "{0} আইটেম"
 msgid "{0} rows"
 msgstr "{0} সারি"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "এই কথোপকথন মুছে ফেলবেন?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "কথোপকথন মুছতে ব্যর্থ হয়েছে।"
+

--- a/ask_alyf/locale/bn.po
+++ b/ask_alyf/locale/bn.po
@@ -87,6 +87,12 @@ msgstr "এজেন্ট মোড অনুমোদন করুন"
 msgid "Allow Code Search"
 msgstr "কোড অনুসন্ধান অনুমোদন করুন"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "কথোপকথন মুছে ফেলার অনুমতি দিন"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/de.po
+++ b/ask_alyf/locale/de.po
@@ -1518,6 +1518,11 @@ msgstr "{0} Einträge"
 msgid "{0} rows"
 msgstr "{0} Zeilen"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "Konversation löschen"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "Diese Konversation löschen?"

--- a/ask_alyf/locale/de.po
+++ b/ask_alyf/locale/de.po
@@ -1512,3 +1512,11 @@ msgstr "{0} Einträge"
 msgid "{0} rows"
 msgstr "{0} Zeilen"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "Diese Konversation löschen?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "Konversation konnte nicht gelöscht werden."
+

--- a/ask_alyf/locale/de.po
+++ b/ask_alyf/locale/de.po
@@ -84,6 +84,12 @@ msgstr "Agentenmodus erlauben"
 msgid "Allow Code Search"
 msgstr "Code-Suche erlauben"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "Konversation löschen erlauben"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/de.po
+++ b/ask_alyf/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-03-16 01:45+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -129,7 +129,7 @@ msgstr "Und {0} weitere."
 msgid "App '{0}' is not installed."
 msgstr "App '{0}' ist nicht installiert."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "Aktion wird angewendet..."
 
@@ -191,7 +191,7 @@ msgstr "ALYF-Fragen ist eine KI und kann Fehler machen, einschließlich mit Zahl
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF bearbeitet noch eine Nachricht in dieser Konversation. Halten Sie sie an oder warten Sie, bis sie abgeschlossen ist, bevor Sie löschen."
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "Diagrammanzeige abgebrochen: {0}."
 msgid "Cancelled the pending operation: {0}."
 msgstr "Ausstehende Operation abgebrochen: {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "Änderungsvorschau"
 
@@ -426,13 +426,13 @@ msgstr "Konfigurieren Sie einen API-Schlüssel in den ALYF-Fragen-Einstellungen,
 msgid "Confirm all"
 msgstr "Alle bestätigen"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "Aktion wird bestätigt..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "Das Löschen von Konversationen ist nicht erlaubt."
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "Der Vorgang konnte nicht abgeschlossen werden: {0}."
 msgid "Could not display chart."
 msgstr "Diagramm konnte nicht angezeigt werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "Diagramm konnte nicht heruntergeladen werden."
 
@@ -467,7 +467,7 @@ msgstr "Visueller Inhalt konnte nicht aus der Datei extrahiert werden."
 msgid "Could not generate content."
 msgstr "Inhalt konnte nicht generiert werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "Diagramm konnte nicht gerendert werden."
 
@@ -505,12 +505,12 @@ msgstr "{0} von {1} {2}-Datensätzen erstellt."
 msgid "Creating several {0} records"
 msgstr "Mehrere {0}-Datensätze werden erstellt"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "Aktuelles Dokument ist {0}, erwartet wurde {1}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "Aktuelles Formular ist {0}, erwartet wurde {1}."
@@ -524,8 +524,8 @@ msgstr "Dataset-Werte müssen numerisch sein."
 msgid "Dataset values must match labels length."
 msgstr "Dataset-Werte müssen der Anzahl der Labels entsprechen."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "Konversation löschen"
 
@@ -589,7 +589,7 @@ msgstr "Dokumentenextraktion hat keinen Inhalt zurückgegeben."
 msgid "Document name is required."
 msgstr "Dokumentname ist erforderlich."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "Diagramm als SVG herunterladen"
 
@@ -647,7 +647,7 @@ msgstr "Fehlgeschlagene Zeilen: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "Datei konnte nicht an die Konversation angehängt werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "Bestätigung der ausstehenden Operation fehlgeschlagen."
 
@@ -655,23 +655,23 @@ msgstr "Bestätigung der ausstehenden Operation fehlgeschlagen."
 msgid "Failed to delete conversation."
 msgstr "Konversation konnte nicht gelöscht werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "Ausführung der Frontend-Aktion fehlgeschlagen."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "Konversation konnte nicht geöffnet werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "Ablehnung der ausstehenden Operation fehlgeschlagen."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "Nachricht konnte nicht gesendet werden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "Der Lauf konnte nicht angehalten werden."
 
@@ -693,8 +693,8 @@ msgstr "Feldagent ist nicht aktiviert."
 msgid "Field updated."
 msgstr "Feld aktualisiert."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "Feld {0} existiert in diesem Formular nicht."
@@ -765,7 +765,7 @@ msgstr "Frontend-Aktion 'set_route' erfordert eine nicht-leere Routenliste."
 msgid "Frontend action failed: {0}"
 msgstr "Frontend-Aktion fehlgeschlagen: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "Der Frontend-Aktion fehlt eine Call-ID."
 
@@ -838,7 +838,7 @@ msgstr "Ich habe die Operation vorbereitet. Bitte prüfen und bestätigen."
 msgid "Invalid action payload."
 msgstr "Ungültige Aktion-Nutzlast."
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "Ungültige Diagrammdaten."
 
@@ -882,7 +882,7 @@ msgstr "Letzte Nachricht am"
 msgid "Line offset {0} exceeds file length"
 msgstr "Zeilenversatz {0} überschreitet die Dateilänge"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "Lade Konversation..."
 
@@ -958,7 +958,7 @@ msgstr "Noch keine Konversationen."
 msgid "No documentation URL was found for app '{0}'."
 msgstr "Für App '{0}' wurde keine Dokumentations-URL gefunden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "Derzeit ist kein Formular geöffnet."
 
@@ -1100,7 +1100,7 @@ msgstr "Pfad muss mit einem installierten App-Namen beginnen."
 msgid "Pending Operation JSON"
 msgstr "Ausstehende Operation JSON"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "Ausstehende Operation"
 
@@ -1240,7 +1240,7 @@ msgstr "Grund: {0}"
 msgid "Reasoning Effort"
 msgstr "Denkaufwand"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "Zu erstellende Datensätze ({0})"
@@ -1320,7 +1320,7 @@ msgstr "Scroll-Aktion benötigt Korrektur."
 msgid "Scroll to field {0}"
 msgstr "Zum Feld {0} scrollen"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "Das Scrollen zu Feldern ist in diesem Formular nicht verfügbar."
 
@@ -1336,7 +1336,7 @@ msgstr "Quellcode wird durchsucht"
 msgid "Selling"
 msgstr "Vertrieb"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "Sende..."
 
@@ -1451,7 +1451,7 @@ msgstr "Generiere immer noch..."
 msgid "Stock"
 msgstr "Lager"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "Diesen Lauf anhalten"
 
@@ -1459,7 +1459,7 @@ msgstr "Diesen Lauf anhalten"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "Angehalten. Senden Sie eine Nachricht, um hier fortzufahren."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "Wird angehalten..."
 
@@ -1613,7 +1613,7 @@ msgstr "Nicht unterstützter Dateityp '{0}'. Unterstützte Typen: PDF, PNG, JPG,
 msgid "Unsupported frontend action '{0}'."
 msgstr "Nicht unterstützte Frontend-Aktion '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "Nicht unterstützte Frontend-Aktion: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Vision-Anbieter"
 msgid "Voice input"
 msgstr "Spracheingabe"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "Eingabe-Sprache: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "Warten auf Antwort..."
 
@@ -1761,7 +1761,7 @@ msgstr "Sie haben keinen Zugriff auf ALYF-Fragen."
 msgid "You do not have read permission on {0}."
 msgstr "Sie haben keine Leseberechtigung auf {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "Ihr Browser unterstützt keine Sprach-Eingabe."
 
@@ -1830,7 +1830,7 @@ msgstr "Sehr hoch"
 msgid "{0} '{1}' was not found."
 msgstr "{0} '{1}' wurde nicht gefunden."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} Zeilen"

--- a/ask_alyf/locale/es.po
+++ b/ask_alyf/locale/es.po
@@ -1580,3 +1580,11 @@ msgstr "{0} elementos"
 msgid "{0} rows"
 msgstr "{0} filas"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "¿Eliminar esta conversación?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "No se pudo eliminar la conversación."
+

--- a/ask_alyf/locale/es.po
+++ b/ask_alyf/locale/es.po
@@ -1586,6 +1586,11 @@ msgstr "{0} elementos"
 msgid "{0} rows"
 msgstr "{0} filas"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "Eliminar conversación"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "¿Eliminar esta conversación?"

--- a/ask_alyf/locale/es.po
+++ b/ask_alyf/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: es\n"
@@ -129,7 +129,7 @@ msgstr "Y {0} más."
 msgid "App '{0}' is not installed."
 msgstr "La aplicación '{0}' no está instalada."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "Aplicando acción..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF es una IA y puede cometer errores, incluso con números e infor
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF todavía está trabajando en un mensaje en esta conversación. Deténgalo o espere a que termine antes de eliminar."
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "Se canceló la visualización del gráfico: {0}."
 msgid "Cancelled the pending operation: {0}."
 msgstr "Se canceló la operación pendiente: {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "Vista previa de cambios"
 
@@ -426,13 +426,13 @@ msgstr "Configure una clave de API en la configuración de Ask ALYF antes de env
 msgid "Confirm all"
 msgstr "Confirmar todo"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "Confirmando acción..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "No se permite eliminar conversaciones."
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "No se pudo completar la operación: {0}."
 msgid "Could not display chart."
 msgstr "No se pudo mostrar el gráfico."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "No se pudo descargar el gráfico."
 
@@ -467,7 +467,7 @@ msgstr "No se pudo extraer el contenido visual del archivo."
 msgid "Could not generate content."
 msgstr "No se pudo generar el contenido."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "No se pudo mostrar el gráfico."
 
@@ -505,12 +505,12 @@ msgstr "Se crearon {0} de {1} registros de {2}."
 msgid "Creating several {0} records"
 msgstr "Creando varios registros de {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "El documento actual es {0}, se esperaba {1}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "El formulario actual es {0}, se esperaba {1}."
@@ -524,8 +524,8 @@ msgstr "Los valores del conjunto de datos deben ser numéricos."
 msgid "Dataset values must match labels length."
 msgstr "Los valores del conjunto de datos deben coincidir con la longitud de las etiquetas."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "Eliminar conversación"
 
@@ -589,7 +589,7 @@ msgstr "La extracción del documento no devolvió contenido."
 msgid "Document name is required."
 msgstr "El nombre del documento es obligatorio."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "Descargar gráfico como SVG"
 
@@ -647,7 +647,7 @@ msgstr "Filas fallidas: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "Error al adjuntar el archivo a la conversación."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "No se pudo confirmar la operación pendiente."
 
@@ -655,23 +655,23 @@ msgstr "No se pudo confirmar la operación pendiente."
 msgid "Failed to delete conversation."
 msgstr "No se pudo eliminar la conversación."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "No se pudo ejecutar la acción del frontend."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "No se pudo abrir la conversación."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "No se pudo rechazar la operación pendiente."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "No se pudo enviar el mensaje."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "No se pudo detener la ejecución."
 
@@ -693,8 +693,8 @@ msgstr "El Agent de campo no está habilitado."
 msgid "Field updated."
 msgstr "Campo actualizado."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "El campo {0} no existe en este formulario."
@@ -765,7 +765,7 @@ msgstr "La acción de frontend 'set_route' requiere una lista de Ruta no vacía.
 msgid "Frontend action failed: {0}"
 msgstr "Acción de frontend fallida: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "A la acción de frontend le falta un ID de Llamada."
 
@@ -838,7 +838,7 @@ msgstr "He preparado la operación. Por favor, revise y confirme."
 msgid "Invalid action payload."
 msgstr "Carga útil de acción no válida."
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "Datos de gráfico no válidos."
 
@@ -882,7 +882,7 @@ msgstr "Último mensaje el"
 msgid "Line offset {0} exceeds file length"
 msgstr "El desplazamiento de línea {0} supera la longitud del archivo"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "Cargando conversación..."
 
@@ -958,7 +958,7 @@ msgstr "Aún no hay conversaciones."
 msgid "No documentation URL was found for app '{0}'."
 msgstr "No se encontró URL de documentación para la aplicación '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "Ningún formulario está abierto actualmente."
 
@@ -1100,7 +1100,7 @@ msgstr "La ruta debe comenzar con el nombre de una aplicación instalada."
 msgid "Pending Operation JSON"
 msgstr "JSON de operación pendiente"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "Operación pendiente"
 
@@ -1240,7 +1240,7 @@ msgstr "Motivo: {0}"
 msgid "Reasoning Effort"
 msgstr "Esfuerzo de razonamiento"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "Registros para crear ({0})"
@@ -1320,7 +1320,7 @@ msgstr "La acción de desplazamiento necesita corrección."
 msgid "Scroll to field {0}"
 msgstr "Desplazarse al campo {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "El desplazamiento a campos no está disponible en este formulario."
 
@@ -1336,7 +1336,7 @@ msgstr "Buscando en el código fuente"
 msgid "Selling"
 msgstr "Ventas"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "Enviando..."
 
@@ -1451,7 +1451,7 @@ msgstr "Generando aún..."
 msgid "Stock"
 msgstr "Inventario"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "Detener esta ejecución"
 
@@ -1459,7 +1459,7 @@ msgstr "Detener esta ejecución"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "Detenido. Envíe un mensaje para continuar desde aquí."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "Deteniendo..."
 
@@ -1613,7 +1613,7 @@ msgstr "Tipo de archivo no soportado '{0}'. Tipos compatibles: PDF, PNG, JPG, GI
 msgid "Unsupported frontend action '{0}'."
 msgstr "Acción de frontend no soportada '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "Acción de frontend no soportada: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Proveedor de Vision"
 msgid "Voice input"
 msgstr "Entrada de voz"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "Idioma de entrada de voz: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "Esperando respuesta..."
 
@@ -1761,7 +1761,7 @@ msgstr "No tiene acceso a Ask ALYF."
 msgid "You do not have read permission on {0}."
 msgstr "No tiene permiso de lectura sobre {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "Su navegador no admite la entrada de voz."
 
@@ -1830,7 +1830,7 @@ msgstr "Muy alto"
 msgid "{0} '{1}' was not found."
 msgstr "No se encontró {0} '{1}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} filas"

--- a/ask_alyf/locale/es.po
+++ b/ask_alyf/locale/es.po
@@ -87,6 +87,12 @@ msgstr "Permitir modo agente"
 msgid "Allow Code Search"
 msgstr "Permitir búsqueda de código"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "Permitir eliminar conversaciones"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/hi.po
+++ b/ask_alyf/locale/hi.po
@@ -1580,3 +1580,11 @@ msgstr "{0} आइटम"
 msgid "{0} rows"
 msgstr "{0} पंक्तियाँ"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "क्या इस वार्तालाप को हटाएं?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "वार्तालाप हटाने में विफल।"
+

--- a/ask_alyf/locale/hi.po
+++ b/ask_alyf/locale/hi.po
@@ -87,6 +87,12 @@ msgstr "एजेंट मोड की अनुमति दें"
 msgid "Allow Code Search"
 msgstr "कोड खोज की अनुमति दें"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "वार्तालाप हटाने की अनुमति दें"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/hi.po
+++ b/ask_alyf/locale/hi.po
@@ -1586,6 +1586,11 @@ msgstr "{0} आइटम"
 msgid "{0} rows"
 msgstr "{0} पंक्तियाँ"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "वार्तालाप हटाएं"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "क्या इस वार्तालाप को हटाएं?"

--- a/ask_alyf/locale/hi.po
+++ b/ask_alyf/locale/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: hi\n"
@@ -129,7 +129,7 @@ msgstr "और {0} अधिक।"
 msgid "App '{0}' is not installed."
 msgstr "ऐप '{0}' संस्थापित नहीं है।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "कार्रवाई लागू की जा रही है..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF एक AI है और गलतियाँ कर सकत�
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF अभी भी इस वार्तालाप में एक संदेश पर काम कर रहा है। हटाने से पहले इसे रोकें या पूरा होने की प्रतीक्षा करें।"
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "चार्ट दिखाना रद्द किया गया: 
 msgid "Cancelled the pending operation: {0}."
 msgstr "लंबित ऑपरेशन रद्द किया गया: {0}।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "परिवर्तनों का पूर्वावलोकन"
 
@@ -426,13 +426,13 @@ msgstr "संदेश भेजने से पहले Ask ALYF सेट�
 msgid "Confirm all"
 msgstr "सभी की पुष्टि करें"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "क्रिया की पुष्टि की जा रही है..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "वार्तालाप हटाने की अनुमति नहीं है।"
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "ऑपरेशन पूरा नहीं किया जा सक�
 msgid "Could not display chart."
 msgstr "चार्ट प्रदर्शित नहीं किया जा सका।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "चार्ट डाउनलोड नहीं किया जा सका।"
 
@@ -467,7 +467,7 @@ msgstr "फ़ाइल से दृश्य सामग्री निक�
 msgid "Could not generate content."
 msgstr "सामग्री उत्पन्न नहीं की जा सकी।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "चार्ट रेंडर नहीं किया जा सका।"
 
@@ -505,12 +505,12 @@ msgstr "{1} में से {0} {2} रिकॉर्ड बनाए गए�
 msgid "Creating several {0} records"
 msgstr "कई {0} रिकॉर्ड बनाए जा रहे हैं"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "वर्तमान दस्तावेज़ {0} है, अपेक्षित {1}।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "वर्तमान फ़ॉर्म {0} है, अपेक्षित {1}।"
@@ -524,8 +524,8 @@ msgstr "डेटासेट के मान संख्यात्मक �
 msgid "Dataset values must match labels length."
 msgstr "डेटासेट के मान लेबल की लंबाई से मेल खाने चाहिए।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "वार्तालाप हटाएं"
 
@@ -589,7 +589,7 @@ msgstr "दस्तावेज़ निष्कर्षण ने कोई
 msgid "Document name is required."
 msgstr "दस्तावेज़ का नाम आवश्यक है।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "चार्ट को SVG के रूप में डाउनलोड करें"
 
@@ -647,7 +647,7 @@ msgstr "विफल पंक्तियाँ: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "वार्तालाप में फ़ाइल संलग्न करने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "लंबित ऑपरेशन की पुष्टि करने में विफल।"
 
@@ -655,23 +655,23 @@ msgstr "लंबित ऑपरेशन की पुष्टि करन�
 msgid "Failed to delete conversation."
 msgstr "वार्तालाप हटाने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "फ्रंटएंड क्रिया निष्पादित करने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "बातचीत खोलने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "लंबित ऑपरेशन को अस्वीकार करने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "संदेश भेजने में विफल।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "रन को रोका नहीं जा सका।"
 
@@ -693,8 +693,8 @@ msgstr "फ़ील्ड Agent सक्षम नहीं है।"
 msgid "Field updated."
 msgstr "फ़ील्ड अपडेट किया गया।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "इस फ़ॉर्म पर फ़ील्ड {0} मौजूद नहीं है।"
@@ -765,7 +765,7 @@ msgstr "फ्रंटएंड क्रिया 'set_route' के लिए
 msgid "Frontend action failed: {0}"
 msgstr "फ्रंटएंड क्रिया विफल: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "फ्रंटएंड क्रिया में एक कॉल ID अनुपस्थित है।"
 
@@ -838,7 +838,7 @@ msgstr "मैंने ऑपरेशन तैयार कर लिया �
 msgid "Invalid action payload."
 msgstr "अमान्य क्रिया पेलोड।"
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "अमान्य चार्ट डेटा।"
 
@@ -882,7 +882,7 @@ msgstr "अंतिम संदेश पर"
 msgid "Line offset {0} exceeds file length"
 msgstr "लाइन ऑफ़सेट {0} फ़ाइल की लंबाई से अधिक है"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "वार्तालाप लोड हो रहा है..."
 
@@ -958,7 +958,7 @@ msgstr "अभी तक कोई बातचीत नहीं।"
 msgid "No documentation URL was found for app '{0}'."
 msgstr "ऐप '{0}' के लिए कोई दस्तावेज़ URL नहीं मिला।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "वर्तमान में कोई फ़ॉर्म खुला नहीं है।"
 
@@ -1100,7 +1100,7 @@ msgstr "Path को एक स्थापित ऐप के नाम से 
 msgid "Pending Operation JSON"
 msgstr "लंबित ऑपरेशन JSON"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "लंबित ऑपरेशन"
 
@@ -1240,7 +1240,7 @@ msgstr "कारण: {0}"
 msgid "Reasoning Effort"
 msgstr "तर्क प्रयास"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "बनाए जाने वाले रिकॉर्ड ({0})"
@@ -1320,7 +1320,7 @@ msgstr "स्क्रॉल क्रिया में सुधार क�
 msgid "Scroll to field {0}"
 msgstr "फ़ील्ड {0} पर स्क्रॉल करें"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "इस फॉर्म पर फ़ील्ड्स तक स्क्रॉल करना उपलब्ध नहीं है।"
 
@@ -1336,7 +1336,7 @@ msgstr "सोर्स कोड में खोज की जा रही �
 msgid "Selling"
 msgstr "बिक्री"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "भेजा जा रहा है..."
 
@@ -1451,7 +1451,7 @@ msgstr "अभी भी जनरेट हो रहा है..."
 msgid "Stock"
 msgstr "स्टॉक"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "इस रन को रोकें"
 
@@ -1459,7 +1459,7 @@ msgstr "इस रन को रोकें"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "रोक दिया गया। यहाँ से आगे बढ़ने के लिए एक संदेश भेजें।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "रोका जा रहा है..."
 
@@ -1613,7 +1613,7 @@ msgstr "असमर्थित फ़ाइल प्रकार '{0}'। स
 msgid "Unsupported frontend action '{0}'."
 msgstr "असमर्थित फ्रंटएंड क्रिया '{0}'।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "असमर्थित फ्रंटएंड क्रिया: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Vision प्रदाता"
 msgid "Voice input"
 msgstr "वॉइस इनपुट"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "वॉइस इनपुट भाषा: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "प्रतिक्रिया की प्रतीक्षा हो रही है..."
 
@@ -1761,7 +1761,7 @@ msgstr "आपके पास Ask ALYF तक पहुँच नहीं ह�
 msgid "You do not have read permission on {0}."
 msgstr "आपके पास {0} पर पढ़ने की अनुमति नहीं है।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "आपका ब्राउज़र वॉइस इनपुट का समर्थन नहीं करता है।"
 
@@ -1830,7 +1830,7 @@ msgstr "अति उच्च"
 msgid "{0} '{1}' was not found."
 msgstr "{0} '{1}' नहीं मिला।"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} पंक्तियाँ"

--- a/ask_alyf/locale/ja.po
+++ b/ask_alyf/locale/ja.po
@@ -1580,3 +1580,11 @@ msgstr "{0} 件"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "この会話を削除しますか？"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "会話を削除できませんでした。"
+

--- a/ask_alyf/locale/ja.po
+++ b/ask_alyf/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: ja\n"
@@ -129,7 +129,7 @@ msgstr "他に {0} 件。"
 msgid "App '{0}' is not installed."
 msgstr "アプリ '{0}' はインストールされていません。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "アクションを適用しています..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF は AI であり、数値や人物に関する情報を含め�
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF はこの会話でメッセージをまだ処理中です。削除する前に処理を停止するか、完了するまでお待ちください。"
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "グラフの表示をキャンセルしました: {0}。"
 msgid "Cancelled the pending operation: {0}."
 msgstr "保留中の操作をキャンセルしました: {0}。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "変更のプレビュー"
 
@@ -426,13 +426,13 @@ msgstr "メッセージを送信する前に、Ask ALYF 設定で API キーを�
 msgid "Confirm all"
 msgstr "すべて確認"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "アクションを確認しています..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "会話の削除は許可されていません。"
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "操作を完了できませんでした: {0}。"
 msgid "Could not display chart."
 msgstr "チャートを表示できませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "チャートをダウンロードできませんでした。"
 
@@ -467,7 +467,7 @@ msgstr "ファイルからビジュアルコンテンツを抽出できません
 msgid "Could not generate content."
 msgstr "コンテンツを生成できませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "チャートを表示できませんでした。"
 
@@ -505,12 +505,12 @@ msgstr "{1} 件中 {0} 件の {2} レコードを作成しました。"
 msgid "Creating several {0} records"
 msgstr "複数の {0} レコードを作成しています"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "現在のドキュメントは {0} ですが、{1} が想定されています。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "現在のフォームは {0} ですが、{1} が想定されています。"
@@ -524,8 +524,8 @@ msgstr "データセットの値は数値でなければなりません。"
 msgid "Dataset values must match labels length."
 msgstr "データセットの値はラベルの長さと一致する必要があります。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "会話を削除"
 
@@ -589,7 +589,7 @@ msgstr "ドキュメント抽出からコンテンツが返されませんでし
 msgid "Document name is required."
 msgstr "ドキュメント名は必須です。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "チャートをSVGとしてダウンロード"
 
@@ -647,7 +647,7 @@ msgstr "失敗した行: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "会話へのファイルの添付に失敗しました。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "保留中の操作の確認に失敗しました。"
 
@@ -655,23 +655,23 @@ msgstr "保留中の操作の確認に失敗しました。"
 msgid "Failed to delete conversation."
 msgstr "会話を削除できませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "フロントエンドアクションの実行に失敗しました。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "会話を開けませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "保留中の操作の拒否に失敗しました。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "メッセージの送信に失敗しました。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "実行を停止できませんでした。"
 
@@ -693,8 +693,8 @@ msgstr "フィールド Agent が有効になっていません。"
 msgid "Field updated."
 msgstr "フィールドを更新しました。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "フィールド {0} はこのフォームに存在しません。"
@@ -765,7 +765,7 @@ msgstr "フロントエンドアクション 'set_route' には空でない Rout
 msgid "Frontend action failed: {0}"
 msgstr "フロントエンドアクションが失敗しました: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "フロントエンドアクションに通話 ID がありません。"
 
@@ -838,7 +838,7 @@ msgstr "操作の準備ができました。ご確認の上、承認してくだ
 msgid "Invalid action payload."
 msgstr "無効なアクションペイロードです。"
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "無効なチャートデータです。"
 
@@ -882,7 +882,7 @@ msgstr "最終メッセージ日時"
 msgid "Line offset {0} exceeds file length"
 msgstr "行オフセット {0} がファイルの長さを超えています"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "会話を読み込んでいます..."
 
@@ -958,7 +958,7 @@ msgstr "まだ会話はありません。"
 msgid "No documentation URL was found for app '{0}'."
 msgstr "アプリ '{0}' のドキュメント URL が見つかりませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "現在開いているフォームはありません。"
 
@@ -1100,7 +1100,7 @@ msgstr "パスはインストール済みアプリ名で始まる必要があり
 msgid "Pending Operation JSON"
 msgstr "保留中の操作 JSON"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "保留中の操作"
 
@@ -1240,7 +1240,7 @@ msgstr "理由: {0}"
 msgid "Reasoning Effort"
 msgstr "推論の労力"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "作成するレコード ({0})"
@@ -1320,7 +1320,7 @@ msgstr "スクロールアクションを修正する必要があります。"
 msgid "Scroll to field {0}"
 msgstr "フィールド {0} へスクロール"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "このフォームではフィールドへのスクロールは利用できません。"
 
@@ -1336,7 +1336,7 @@ msgstr "ソースコードを検索中"
 msgid "Selling"
 msgstr "販売"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "送信中..."
 
@@ -1451,7 +1451,7 @@ msgstr "生成中..."
 msgid "Stock"
 msgstr "在庫"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "この実行を停止"
 
@@ -1459,7 +1459,7 @@ msgstr "この実行を停止"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "停止しました。ここから再開するにはメッセージを送信してください。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "停止中..."
 
@@ -1613,7 +1613,7 @@ msgstr "サポートされていないファイルタイプ '{0}'。サポート
 msgid "Unsupported frontend action '{0}'."
 msgstr "サポートされていないフロントエンドアクション '{0}'。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "サポートされていないフロントエンドアクション: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Vision プロバイダー"
 msgid "Voice input"
 msgstr "音声入力"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "音声入力言語: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "応答を待っています..."
 
@@ -1761,7 +1761,7 @@ msgstr "Ask ALYF へのアクセス権限がありません。"
 msgid "You do not have read permission on {0}."
 msgstr "{0} に対する読み取り権限がありません。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "お使いのブラウザは音声入力に対応していません。"
 
@@ -1830,7 +1830,7 @@ msgstr "超高"
 msgid "{0} '{1}' was not found."
 msgstr "{0} '{1}' は見つかりませんでした。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} 行"

--- a/ask_alyf/locale/ja.po
+++ b/ask_alyf/locale/ja.po
@@ -87,6 +87,12 @@ msgstr "エージェントモードを許可"
 msgid "Allow Code Search"
 msgstr "コード検索を許可"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "会話の削除を許可"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/ja.po
+++ b/ask_alyf/locale/ja.po
@@ -1586,6 +1586,11 @@ msgstr "{0} 件"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "会話を削除"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "この会話を削除しますか？"

--- a/ask_alyf/locale/main.pot
+++ b/ask_alyf/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
-"PO-Revision-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
+"PO-Revision-Date: 2026-09-02 11:03+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -120,7 +120,7 @@ msgstr ""
 msgid "App '{0}' is not installed."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr ""
 
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Cancelled the pending operation: {0}."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr ""
 
@@ -406,7 +406,7 @@ msgstr ""
 msgid "Confirm all"
 msgstr ""
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr ""
 
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Could not display chart."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr ""
 
@@ -446,7 +446,7 @@ msgstr ""
 msgid "Could not generate content."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr ""
 
@@ -478,11 +478,11 @@ msgstr ""
 msgid "Creating several {0} records"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 msgid "Current document is {0}, expected {1}."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 msgid "Current form is {0}, expected {1}."
 msgstr ""
 
@@ -495,8 +495,8 @@ msgstr ""
 msgid "Dataset values must match labels length."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "Document name is required."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Failed to attach file to conversation."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr ""
 
@@ -621,23 +621,23 @@ msgstr ""
 msgid "Failed to delete conversation."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr ""
 
@@ -657,8 +657,8 @@ msgstr ""
 msgid "Field updated."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 msgid "Field {0} does not exist on this form."
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Frontend action failed: {0}"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Invalid action payload."
 msgstr ""
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr ""
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Line offset {0} exceeds file length"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr ""
 
@@ -914,7 +914,7 @@ msgstr ""
 msgid "No documentation URL was found for app '{0}'."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Pending Operation JSON"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Reasoning Effort"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 msgid "Records to create ({0})"
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 msgid "Scroll to field {0}"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Selling"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr ""
 
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Stock"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr ""
 
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "Stopped. Send a message to pick up from here."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr ""
 
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Unsupported frontend action '{0}'."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 msgid "Unsupported frontend action: {0}"
 msgstr ""
 
@@ -1613,11 +1613,11 @@ msgstr ""
 msgid "Voice input"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 msgid "Voice input language: {0}"
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr ""
 
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "You do not have read permission on {0}."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "{0} '{1}' was not found."
 msgstr ""
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 msgid "{0} rows"
 msgstr ""
 

--- a/ask_alyf/locale/main.pot
+++ b/ask_alyf/locale/main.pot
@@ -1516,6 +1516,11 @@ msgstr ""
 msgid "{0} rows"
 msgstr ""
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr ""
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr ""

--- a/ask_alyf/locale/main.pot
+++ b/ask_alyf/locale/main.pot
@@ -82,6 +82,12 @@ msgstr ""
 msgid "Allow Code Search"
 msgstr ""
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr ""
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/main.pot
+++ b/ask_alyf/locale/main.pot
@@ -1510,3 +1510,11 @@ msgstr ""
 msgid "{0} rows"
 msgstr ""
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr ""
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr ""
+

--- a/ask_alyf/locale/pt.po
+++ b/ask_alyf/locale/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: pt\n"
@@ -129,7 +129,7 @@ msgstr "E mais {0}."
 msgid "App '{0}' is not installed."
 msgstr "A aplicação '{0}' não está instalada."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "A aplicar ação..."
 
@@ -191,7 +191,7 @@ msgstr "O Ask ALYF é uma IA e pode cometer erros, incluindo com números e info
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "O Ask ALYF ainda está a trabalhar numa mensagem nesta conversa. Pare ou aguarde até que termine antes de eliminar."
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "Exibição do gráfico cancelada: {0}."
 msgid "Cancelled the pending operation: {0}."
 msgstr "Operação pendente cancelada: {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "Pré-visualização das alterações"
 
@@ -426,13 +426,13 @@ msgstr "Configure uma chave de API nas Definições do Ask ALYF antes de enviar 
 msgid "Confirm all"
 msgstr "Confirmar tudo"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "A confirmar ação..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "Não é permitido eliminar conversas."
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "Não foi possível concluir a operação: {0}."
 msgid "Could not display chart."
 msgstr "Não foi possível exibir o gráfico."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "Não foi possível descarregar o gráfico."
 
@@ -467,7 +467,7 @@ msgstr "Não foi possível extrair o conteúdo visual do ficheiro."
 msgid "Could not generate content."
 msgstr "Não foi possível gerar o conteúdo."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "Não foi possível apresentar o gráfico."
 
@@ -505,12 +505,12 @@ msgstr "Criados {0} de {1} registos de {2}."
 msgid "Creating several {0} records"
 msgstr "A criar vários registos de {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "O documento atual é {0}, esperado {1}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "O formulário atual é {0}, esperado {1}."
@@ -524,8 +524,8 @@ msgstr "Os valores do conjunto de dados devem ser numéricos."
 msgid "Dataset values must match labels length."
 msgstr "Os valores do conjunto de dados devem corresponder ao comprimento das etiquetas."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "Excluir conversa"
 
@@ -589,7 +589,7 @@ msgstr "A extração do documento não retornou conteúdo."
 msgid "Document name is required."
 msgstr "O nome do documento é obrigatório."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "Baixar gráfico como SVG"
 
@@ -647,7 +647,7 @@ msgstr "Linhas falhadas: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "Falha ao anexar o ficheiro à conversa."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "Falha ao confirmar operação pendente."
 
@@ -655,23 +655,23 @@ msgstr "Falha ao confirmar operação pendente."
 msgid "Failed to delete conversation."
 msgstr "Falha ao excluir conversa."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "Falha ao executar ação de frontend."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "Falha ao abrir conversa."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "Falha ao rejeitar operação pendente."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "Falha ao enviar mensagem."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "Não foi possível parar a execução."
 
@@ -693,8 +693,8 @@ msgstr "O Agent de campo não está ativado."
 msgid "Field updated."
 msgstr "Campo atualizado."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "O campo {0} não existe neste formulário."
@@ -765,7 +765,7 @@ msgstr "A ação de frontend 'set_route' requer uma lista de Rota não vazia."
 msgid "Frontend action failed: {0}"
 msgstr "Ação de frontend falhada: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "Falta um ID de Chamada na ação de frontend."
 
@@ -838,7 +838,7 @@ msgstr "Preparei a operação. Por favor, reveja e confirme."
 msgid "Invalid action payload."
 msgstr "Carga útil de ação inválida."
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "Dados de gráfico inválidos."
 
@@ -882,7 +882,7 @@ msgstr "Última mensagem em"
 msgid "Line offset {0} exceeds file length"
 msgstr "O deslocamento de linha {0} excede o comprimento do ficheiro"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "A carregar conversa..."
 
@@ -958,7 +958,7 @@ msgstr "Ainda não há conversas."
 msgid "No documentation URL was found for app '{0}'."
 msgstr "Nenhuma URL de documentação foi encontrada para a aplicação '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "Nenhum formulário está aberto no momento."
 
@@ -1100,7 +1100,7 @@ msgstr "O caminho deve começar com o nome de uma aplicação instalada."
 msgid "Pending Operation JSON"
 msgstr "JSON de operação pendente"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "Operação pendente"
 
@@ -1240,7 +1240,7 @@ msgstr "Motivo: {0}"
 msgid "Reasoning Effort"
 msgstr "Esforço de raciocínio"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "Registos a criar ({0})"
@@ -1320,7 +1320,7 @@ msgstr "A ação de rolagem precisa de correção."
 msgid "Scroll to field {0}"
 msgstr "Rolar até o campo {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "A rolagem para campos não está disponível neste formulário."
 
@@ -1336,7 +1336,7 @@ msgstr "A pesquisar no código fonte"
 msgid "Selling"
 msgstr "Vendas"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "Enviando..."
 
@@ -1451,7 +1451,7 @@ msgstr "Ainda a gerar..."
 msgid "Stock"
 msgstr "Stock"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "Parar esta execução"
 
@@ -1459,7 +1459,7 @@ msgstr "Parar esta execução"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "Parado. Envie uma mensagem para continuar a partir daqui."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "A parar..."
 
@@ -1613,7 +1613,7 @@ msgstr "Tipo de ficheiro não suportado '{0}'. Tipos suportados: PDF, PNG, JPG, 
 msgid "Unsupported frontend action '{0}'."
 msgstr "Ação de frontend não suportada '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "Ação de frontend não suportada: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Provedor de Vision"
 msgid "Voice input"
 msgstr "Entrada de voz"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "Idioma da entrada de voz: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "Aguardando resposta..."
 
@@ -1761,7 +1761,7 @@ msgstr "Você não tem acesso ao Ask ALYF."
 msgid "You do not have read permission on {0}."
 msgstr "Você não tem permissão de leitura em {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "O seu navegador não suporta entrada de voz."
 
@@ -1830,7 +1830,7 @@ msgstr "Muito alto"
 msgid "{0} '{1}' was not found."
 msgstr "{0} '{1}' não foi encontrado."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} linhas"

--- a/ask_alyf/locale/pt.po
+++ b/ask_alyf/locale/pt.po
@@ -87,6 +87,12 @@ msgstr "Permitir modo agente"
 msgid "Allow Code Search"
 msgstr "Permitir pesquisa de código"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "Permitir eliminar conversas"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/pt.po
+++ b/ask_alyf/locale/pt.po
@@ -1586,6 +1586,11 @@ msgstr "{0} itens"
 msgid "{0} rows"
 msgstr "{0} linhas"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "Excluir conversa"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "Excluir esta conversa?"

--- a/ask_alyf/locale/pt.po
+++ b/ask_alyf/locale/pt.po
@@ -1580,3 +1580,11 @@ msgstr "{0} itens"
 msgid "{0} rows"
 msgstr "{0} linhas"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "Excluir esta conversa?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "Falha ao excluir conversa."
+

--- a/ask_alyf/locale/ru.po
+++ b/ask_alyf/locale/ru.po
@@ -1580,3 +1580,11 @@ msgstr "{0} элементов"
 msgid "{0} rows"
 msgstr "{0} строк"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "Удалить этот разговор?"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "Не удалось удалить разговор."
+

--- a/ask_alyf/locale/ru.po
+++ b/ask_alyf/locale/ru.po
@@ -1586,6 +1586,11 @@ msgstr "{0} элементов"
 msgid "{0} rows"
 msgstr "{0} строк"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "Удалить разговор"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "Удалить этот разговор?"

--- a/ask_alyf/locale/ru.po
+++ b/ask_alyf/locale/ru.po
@@ -87,6 +87,12 @@ msgstr "Разрешить режим агента"
 msgid "Allow Code Search"
 msgstr "Разрешить поиск по коду"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "Разрешить удаление разговора"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/ru.po
+++ b/ask_alyf/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: ru\n"
@@ -129,7 +129,7 @@ msgstr "И ещё {0}."
 msgid "App '{0}' is not installed."
 msgstr "Приложение '{0}' не установлено."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "Применение действия..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF — это ИИ, и он может ошибаться, в то
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF всё ещё обрабатывает сообщение в этой беседе. Остановите его или дождитесь завершения перед удалением."
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "Отображение диаграммы отменено: {0}."
 msgid "Cancelled the pending operation: {0}."
 msgstr "Ожидающая операция отменена: {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "Предпросмотр изменений"
 
@@ -426,13 +426,13 @@ msgstr "Настройте API-ключ в настройках Ask ALYF пер�
 msgid "Confirm all"
 msgstr "Подтвердить все"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "Подтверждение действия..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "Удаление бесед не разрешено."
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "Не удалось завершить операцию: {0}."
 msgid "Could not display chart."
 msgstr "Не удалось отобразить диаграмму."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "Не удалось скачать диаграмму."
 
@@ -467,7 +467,7 @@ msgstr "Не удалось извлечь визуальное содержим
 msgid "Could not generate content."
 msgstr "Не удалось сгенерировать содержимое."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "Не удалось отобразить диаграмму."
 
@@ -505,12 +505,12 @@ msgstr "Создано {0} из {1} записей {2}."
 msgid "Creating several {0} records"
 msgstr "Создание нескольких записей {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "Текущий документ — {0}, ожидался {1}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "Текущая форма — {0}, ожидалась {1}."
@@ -524,8 +524,8 @@ msgstr "Значения набора данных должны быть чис�
 msgid "Dataset values must match labels length."
 msgstr "Значения набора данных должны соответствовать длине меток."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "Удалить разговор"
 
@@ -589,7 +589,7 @@ msgstr "Извлечение документа не вернуло содерж
 msgid "Document name is required."
 msgstr "Название документа обязательно."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "Скачать диаграмму в формате SVG"
 
@@ -647,7 +647,7 @@ msgstr "Неуспешные строки: {0}"
 msgid "Failed to attach file to conversation."
 msgstr "Не удалось прикрепить файл к беседе."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "Не удалось подтвердить ожидающую операцию."
 
@@ -655,23 +655,23 @@ msgstr "Не удалось подтвердить ожидающую опера
 msgid "Failed to delete conversation."
 msgstr "Не удалось удалить разговор."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "Не удалось выполнить действие интерфейса."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "Не удалось открыть разговор."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "Не удалось отклонить ожидающую операцию."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "Не удалось отправить сообщение."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "Не удалось остановить выполнение."
 
@@ -693,8 +693,8 @@ msgstr "Полевой Agent не включён."
 msgid "Field updated."
 msgstr "Поле обновлено."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "Поле {0} не существует в этой форме."
@@ -765,7 +765,7 @@ msgstr "Фронтенд-действию 'set_route' требуется неп�
 msgid "Frontend action failed: {0}"
 msgstr "Фронтенд-действие не выполнено: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "У фронтенд-действия отсутствует идентификатор звонка (Call ID)."
 
@@ -838,7 +838,7 @@ msgstr "Я подготовил операцию. Пожалуйста, пров
 msgid "Invalid action payload."
 msgstr "Недопустимые данные действия."
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "Недопустимые данные диаграммы."
 
@@ -882,7 +882,7 @@ msgstr "Последнее сообщение в"
 msgid "Line offset {0} exceeds file length"
 msgstr "Смещение строки {0} превышает длину файла"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "Загрузка беседы..."
 
@@ -958,7 +958,7 @@ msgstr "Пока нет разговоров."
 msgid "No documentation URL was found for app '{0}'."
 msgstr "URL-адрес документации для приложения '{0}' не найден."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "В настоящее время ни одна форма не открыта."
 
@@ -1100,7 +1100,7 @@ msgstr "Путь должен начинаться с имени установ�
 msgid "Pending Operation JSON"
 msgstr "JSON ожидающей операции"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "Ожидающая операция"
 
@@ -1240,7 +1240,7 @@ msgstr "Причина: {0}"
 msgid "Reasoning Effort"
 msgstr "Уровень рассуждений"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "Записи для создания ({0})"
@@ -1320,7 +1320,7 @@ msgstr "Действие прокрутки требует исправлени�
 msgid "Scroll to field {0}"
 msgstr "Прокрутить к полю {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "Прокрутка к полям недоступна на этой форме."
 
@@ -1336,7 +1336,7 @@ msgstr "Поиск в исходном коде"
 msgid "Selling"
 msgstr "Продажи"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "Отправка..."
 
@@ -1451,7 +1451,7 @@ msgstr "Всё ещё создаётся..."
 msgid "Stock"
 msgstr "Склад"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "Остановить этот запуск"
 
@@ -1459,7 +1459,7 @@ msgstr "Остановить этот запуск"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "Приостановлено. Отправьте сообщение, чтобы продолжить с этого места."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "Остановка..."
 
@@ -1613,7 +1613,7 @@ msgstr "Неподдерживаемый тип файла '{0}'. Поддерж
 msgid "Unsupported frontend action '{0}'."
 msgstr "Неподдерживаемое действие фронтенда '{0}'."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "Неподдерживаемое действие фронтенда: {0}"
@@ -1694,12 +1694,12 @@ msgstr "Провайдер Vision"
 msgid "Voice input"
 msgstr "Голосовой ввод"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "Язык голосового ввода: {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "Ожидание ответа..."
 
@@ -1761,7 +1761,7 @@ msgstr "У вас нет доступа к Ask ALYF."
 msgid "You do not have read permission on {0}."
 msgstr "У вас нет разрешения на чтение для {0}."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "Ваш браузер не поддерживает голосовой ввод."
 
@@ -1830,7 +1830,7 @@ msgstr "Очень высокий"
 msgid "{0} '{1}' was not found."
 msgstr "{0} «{1}» не найден."
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} строк"

--- a/ask_alyf/locale/zh_CN.po
+++ b/ask_alyf/locale/zh_CN.po
@@ -87,6 +87,12 @@ msgstr "允许代理模式"
 msgid "Allow Code Search"
 msgstr "允许代码搜索"
 
+#. Label of the allow_conversation_deletion (Check) field in DocType 'Ask ALYF
+#. Settings'
+#: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
+msgid "Allow Conversation Deletion"
+msgstr "允许删除对话"
+
 #. Label of the allow_field_agent (Check) field in DocType 'Ask ALYF Settings'
 #: ask_alyf/ask_alyf/doctype/ask_alyf_settings/ask_alyf_settings.json
 msgid "Allow Field Agent"

--- a/ask_alyf/locale/zh_CN.po
+++ b/ask_alyf/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ask ALYF VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-09-02 01:38+0053\n"
+"POT-Creation-Date: 2026-09-02 11:03+0053\n"
 "PO-Revision-Date: 2026-05-02 19:04+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: zh_CN\n"
@@ -129,7 +129,7 @@ msgstr "还有 {0} 个。"
 msgid "App '{0}' is not installed."
 msgstr "应用 '{0}' 未安装。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Applying action..."
 msgstr "正在应用操作..."
 
@@ -191,7 +191,7 @@ msgstr "Ask ALYF 是一个 AI，可能会出错，包括关于数字和人员信
 
 #: ask_alyf/ask_alyf/api.py:432
 msgid "Ask ALYF is still working on a message in this conversation. Stop it or wait for it to finish before deleting."
-msgstr ""
+msgstr "Ask ALYF 仍在处理此对话中的一条消息。删除前请先停止或等待其完成。"
 
 #: ask_alyf/ask_alyf/api.py:463
 msgid "Ask ALYF is still working on the previous message in this conversation."
@@ -297,7 +297,7 @@ msgstr "已取消显示图表：{0}。"
 msgid "Cancelled the pending operation: {0}."
 msgstr "已取消挂起的操作：{0}。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2217
+#: ask_alyf/public/js/ask_alyf.bundle.js:2222
 msgid "Changes preview"
 msgstr "变更预览"
 
@@ -426,13 +426,13 @@ msgstr "发送消息前，请在 Ask ALYF 设置中配置 API 密钥。"
 msgid "Confirm all"
 msgstr "全部确认"
 
-#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2501
+#: ask_alyf/ask_alyf/api.py:736 ask_alyf/public/js/ask_alyf.bundle.js:2506
 msgid "Confirming action..."
 msgstr "正在确认操作..."
 
 #: ask_alyf/ask_alyf/api.py:426
 msgid "Conversation deletion is not allowed."
-msgstr ""
+msgstr "不允许删除对话。"
 
 #: ask_alyf/ask_alyf/tools.py:991
 msgid "Conversation name is required."
@@ -455,7 +455,7 @@ msgstr "无法完成操作：{0}。"
 msgid "Could not display chart."
 msgstr "无法显示图表。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2720
+#: ask_alyf/public/js/ask_alyf.bundle.js:2725
 msgid "Could not download chart."
 msgstr "无法下载图表。"
 
@@ -467,7 +467,7 @@ msgstr "无法从文件中提取视觉内容。"
 msgid "Could not generate content."
 msgstr "无法生成内容。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2791
+#: ask_alyf/public/js/ask_alyf.bundle.js:2796
 msgid "Could not render chart."
 msgstr "无法渲染图表。"
 
@@ -505,12 +505,12 @@ msgstr "已创建 {1} 条 {2} 记录中的 {0} 条。"
 msgid "Creating several {0} records"
 msgstr "正在创建多条 {0} 记录"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2365
+#: ask_alyf/public/js/ask_alyf.bundle.js:2370
 #, python-brace-format
 msgid "Current document is {0}, expected {1}."
 msgstr "当前单据为 {0},预期为 {1}。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2358
+#: ask_alyf/public/js/ask_alyf.bundle.js:2363
 #, python-brace-format
 msgid "Current form is {0}, expected {1}."
 msgstr "当前表单为 {0},预期为 {1}。"
@@ -524,8 +524,8 @@ msgstr "数据集的值必须为数字。"
 msgid "Dataset values must match labels length."
 msgstr "数据集的值必须与标签长度匹配。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1701
-#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+#: ask_alyf/public/js/ask_alyf.bundle.js:1706
+#: ask_alyf/public/js/ask_alyf.bundle.js:1707
 msgid "Delete conversation"
 msgstr "删除对话"
 
@@ -589,7 +589,7 @@ msgstr "单据提取未返回任何内容。"
 msgid "Document name is required."
 msgstr "单据编号为必填项。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2705
+#: ask_alyf/public/js/ask_alyf.bundle.js:2710
 msgid "Download chart as SVG"
 msgstr "将图表下载为 SVG"
 
@@ -647,7 +647,7 @@ msgstr "失败的行:{0}"
 msgid "Failed to attach file to conversation."
 msgstr "未能将文件附加到对话。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2528
+#: ask_alyf/public/js/ask_alyf.bundle.js:2533
 msgid "Failed to confirm pending operation."
 msgstr "确认待处理操作失败。"
 
@@ -655,23 +655,23 @@ msgstr "确认待处理操作失败。"
 msgid "Failed to delete conversation."
 msgstr "删除对话失败。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2466
+#: ask_alyf/public/js/ask_alyf.bundle.js:2471
 msgid "Failed to execute frontend action."
 msgstr "执行前端操作失败。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1744
+#: ask_alyf/public/js/ask_alyf.bundle.js:1749
 msgid "Failed to open conversation."
 msgstr "打开对话失败。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2566
+#: ask_alyf/public/js/ask_alyf.bundle.js:2571
 msgid "Failed to reject pending operation."
 msgstr "拒绝待处理操作失败。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2086
+#: ask_alyf/public/js/ask_alyf.bundle.js:2091
 msgid "Failed to send message."
 msgstr "发送消息失败。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1832
+#: ask_alyf/public/js/ask_alyf.bundle.js:1837
 msgid "Failed to stop the run."
 msgstr "无法停止本次运行。"
 
@@ -693,8 +693,8 @@ msgstr "字段 Agent 未启用。"
 msgid "Field updated."
 msgstr "字段已更新。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2395
-#: ask_alyf/public/js/ask_alyf.bundle.js:2404
+#: ask_alyf/public/js/ask_alyf.bundle.js:2400
+#: ask_alyf/public/js/ask_alyf.bundle.js:2409
 #, python-brace-format
 msgid "Field {0} does not exist on this form."
 msgstr "此表单上不存在字段 {0}。"
@@ -765,7 +765,7 @@ msgstr "前端操作 'set_route' 需要一个非空的路由列表。"
 msgid "Frontend action failed: {0}"
 msgstr "前端操作失败:{0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2453
+#: ask_alyf/public/js/ask_alyf.bundle.js:2458
 msgid "Frontend action is missing a call ID."
 msgstr "前端操作缺少通话 ID。"
 
@@ -838,7 +838,7 @@ msgstr "我已准备好该操作。请审核并确认。"
 msgid "Invalid action payload."
 msgstr "无效的操作负载。"
 
-#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2761
+#: ask_alyf/ask_alyf/tools.py:1609 ask_alyf/public/js/ask_alyf.bundle.js:2766
 msgid "Invalid chart data."
 msgstr "无效的图表数据。"
 
@@ -882,7 +882,7 @@ msgstr "最后消息时间"
 msgid "Line offset {0} exceeds file length"
 msgstr "行偏移 {0} 超出文件长度"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1729
+#: ask_alyf/public/js/ask_alyf.bundle.js:1734
 msgid "Loading conversation..."
 msgstr "正在加载对话..."
 
@@ -958,7 +958,7 @@ msgstr "暂无对话。"
 msgid "No documentation URL was found for app '{0}'."
 msgstr "未找到应用 '{0}' 的文档URL。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2352
+#: ask_alyf/public/js/ask_alyf.bundle.js:2357
 msgid "No form is currently open."
 msgstr "当前没有打开的表单。"
 
@@ -1100,7 +1100,7 @@ msgstr "路径必须以已安装的应用名称开头。"
 msgid "Pending Operation JSON"
 msgstr "待处理操作 JSON"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2171
+#: ask_alyf/public/js/ask_alyf.bundle.js:2176
 msgid "Pending operation"
 msgstr "待处理操作"
 
@@ -1240,7 +1240,7 @@ msgstr "原因：{0}"
 msgid "Reasoning Effort"
 msgstr "推理强度"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2264
+#: ask_alyf/public/js/ask_alyf.bundle.js:2269
 #, python-brace-format
 msgid "Records to create ({0})"
 msgstr "要创建的记录 ({0})"
@@ -1320,7 +1320,7 @@ msgstr "滚动操作需要更正。"
 msgid "Scroll to field {0}"
 msgstr "滚动到字段 {0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2386
+#: ask_alyf/public/js/ask_alyf.bundle.js:2391
 msgid "Scrolling to fields is not available on this form."
 msgstr "此表单不支持滚动到字段。"
 
@@ -1336,7 +1336,7 @@ msgstr "正在搜索源代码"
 msgid "Selling"
 msgstr "销售"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2026
+#: ask_alyf/public/js/ask_alyf.bundle.js:2031
 msgid "Sending..."
 msgstr "正在发送..."
 
@@ -1451,7 +1451,7 @@ msgstr "仍在生成中..."
 msgid "Stock"
 msgstr "库存"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1793
+#: ask_alyf/public/js/ask_alyf.bundle.js:1798
 msgid "Stop this run"
 msgstr "停止本次运行"
 
@@ -1459,7 +1459,7 @@ msgstr "停止本次运行"
 msgid "Stopped. Send a message to pick up from here."
 msgstr "已停止。发送消息即可从此处继续。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:1814
+#: ask_alyf/public/js/ask_alyf.bundle.js:1819
 msgid "Stopping..."
 msgstr "正在停止..."
 
@@ -1613,7 +1613,7 @@ msgstr "不支持的文件类型 '{0}'。支持的类型：PDF、PNG、JPG、GIF
 msgid "Unsupported frontend action '{0}'."
 msgstr "不支持的前端操作 '{0}'。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2415
+#: ask_alyf/public/js/ask_alyf.bundle.js:2420
 #, python-brace-format
 msgid "Unsupported frontend action: {0}"
 msgstr "不支持的前端操作：{0}"
@@ -1694,12 +1694,12 @@ msgstr "Vision 提供商"
 msgid "Voice input"
 msgstr "语音输入"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2913
+#: ask_alyf/public/js/ask_alyf.bundle.js:2918
 #, python-brace-format
 msgid "Voice input language: {0}"
 msgstr "语音输入语言：{0}"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2074
+#: ask_alyf/public/js/ask_alyf.bundle.js:2079
 msgid "Waiting for response..."
 msgstr "正在等待回复..."
 
@@ -1761,7 +1761,7 @@ msgstr "您无权访问 Ask ALYF。"
 msgid "You do not have read permission on {0}."
 msgstr "您没有 {0} 的读取权限。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2854
+#: ask_alyf/public/js/ask_alyf.bundle.js:2859
 msgid "Your browser does not support voice input."
 msgstr "您的浏览器不支持语音输入。"
 
@@ -1830,7 +1830,7 @@ msgstr "超高"
 msgid "{0} '{1}' was not found."
 msgstr "未找到 {0} '{1}'。"
 
-#: ask_alyf/public/js/ask_alyf.bundle.js:2317
+#: ask_alyf/public/js/ask_alyf.bundle.js:2322
 #, python-brace-format
 msgid "{0} rows"
 msgstr "{0} 行"

--- a/ask_alyf/locale/zh_CN.po
+++ b/ask_alyf/locale/zh_CN.po
@@ -1580,3 +1580,11 @@ msgstr "{0} 个项目"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1234
+msgid "Delete this conversation?"
+msgstr "删除此对话？"
+
+#: ask_alyf/public/js/ask_alyf.bundle.js:1238
+msgid "Failed to delete conversation."
+msgstr "删除对话失败。"
+

--- a/ask_alyf/locale/zh_CN.po
+++ b/ask_alyf/locale/zh_CN.po
@@ -1586,6 +1586,11 @@ msgstr "{0} 个项目"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#: ask_alyf/public/js/ask_alyf.bundle.js:1701
+#: ask_alyf/public/js/ask_alyf.bundle.js:1702
+msgid "Delete conversation"
+msgstr "删除对话"
+
 #: ask_alyf/public/js/ask_alyf.bundle.js:1234
 msgid "Delete this conversation?"
 msgstr "删除此对话？"

--- a/ask_alyf/public/css/ask_alyf.bundle.css
+++ b/ask_alyf/public/css/ask_alyf.bundle.css
@@ -444,17 +444,31 @@
 
 .ask_alyf-history-item {
 	width: 100%;
-	text-align: left;
 	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 0.2rem;
+	flex-direction: row;
+	align-items: stretch;
+	gap: 0.35rem;
 	transition: transform 0.16s cubic-bezier(0.25, 1, 0.5, 1),
 		box-shadow 0.2s ease;
 }
 
 .ask_alyf-history-item:hover {
 	transform: translateY(-1px);
+}
+
+.ask_alyf-history-item-main {
+	flex: 1 1 auto;
+	min-width: 0;
+	text-align: left;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.2rem;
+}
+
+.ask_alyf-history-item-delete {
+	flex: 0 0 auto;
+	align-self: stretch;
 }
 
 .ask_alyf-history-item-title {

--- a/ask_alyf/public/css/ask_alyf.bundle.css
+++ b/ask_alyf/public/css/ask_alyf.bundle.css
@@ -443,11 +443,8 @@
 }
 
 .ask_alyf-history-item {
+	position: relative;
 	width: 100%;
-	display: flex;
-	flex-direction: row;
-	align-items: stretch;
-	gap: 0.35rem;
 	transition: transform 0.16s cubic-bezier(0.25, 1, 0.5, 1),
 		box-shadow 0.2s ease;
 }
@@ -457,7 +454,7 @@
 }
 
 .ask_alyf-history-item-main {
-	flex: 1 1 auto;
+	width: 100%;
 	min-width: 0;
 	text-align: left;
 	display: flex;
@@ -467,14 +464,33 @@
 }
 
 .ask_alyf-history-item-delete {
-	flex: 0 0 auto;
-	align-self: stretch;
+	position: absolute;
+	top: 50%;
+	right: 0.3rem;
+	transform: translateY(-50%);
+	opacity: 0;
+	pointer-events: none;
+	border: none;
+}
+
+.ask_alyf-history-item-delete:not(:hover) {
+	background: transparent;
+}
+
+.ask_alyf-history-item:hover .ask_alyf-history-item-delete {
+	opacity: 1;
+	pointer-events: auto;
 }
 
 .ask_alyf-history-item-title {
 	font-size: 0.86rem;
 	font-weight: 600;
 	line-height: 1.3;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
+	padding-right: 2rem;
 }
 
 .ask_alyf-history-item-meta {

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -1697,7 +1697,12 @@ import "./field_agent";
 					const deleteEl = document.createElement("button");
 					deleteEl.type = "button";
 					deleteEl.className =
-						"ask_alyf-history-item-delete ask_alyf-icon-button btn btn-secondary btn-sm";
+						"ask_alyf-history-item-delete ask_alyf-icon-button btn btn-sm";
+					if (conversation.name === currentName) {
+						deleteEl.classList.add("btn-primary");
+					} else {
+						deleteEl.classList.add("btn-secondary");
+					}
 					deleteEl.title = __("Delete conversation");
 					deleteEl.setAttribute("aria-label", __("Delete conversation"));
 					deleteEl.innerHTML = getIcon("trash", "sm", "", true);

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -1696,8 +1696,7 @@ import "./field_agent";
 				if (deletionEnabled) {
 					const deleteEl = document.createElement("button");
 					deleteEl.type = "button";
-					deleteEl.className =
-						"ask_alyf-history-item-delete ask_alyf-icon-button btn btn-sm";
+					deleteEl.className = "ask_alyf-history-item-delete ask_alyf-icon-button btn btn-sm";
 					if (conversation.name === currentName) {
 						deleteEl.classList.add("btn-primary");
 					} else {

--- a/ask_alyf/public/js/ask_alyf.bundle.js
+++ b/ask_alyf/public/js/ask_alyf.bundle.js
@@ -1224,6 +1224,22 @@ import "./field_agent";
 			this.openConversation(conversationName);
 		}
 
+		onHistoryConversationDeleteClick(event, conversationName) {
+			event.preventDefault();
+			event.stopPropagation();
+			if (!conversationName || !this.isConversationDeletionEnabled()) {
+				return;
+			}
+
+			frappe.confirm(__("Delete this conversation?"), async () => {
+				try {
+					await this.deleteConversation(conversationName);
+				} catch (error) {
+					frappe.msgprint(error.message || __("Failed to delete conversation."));
+				}
+			});
+		}
+
 		onModeOptionClick(event) {
 			const option = event.currentTarget;
 			const selectedMode = option?.dataset?.mode;
@@ -1262,6 +1278,10 @@ import "./field_agent";
 
 		isFileUploadEnabled() {
 			return Boolean(frappe?.boot?.ask_alyf?.file_upload_enabled);
+		}
+
+		isConversationDeletionEnabled() {
+			return Boolean(frappe?.boot?.ask_alyf?.conversation_deletion_enabled);
 		}
 
 		syncFileUploadButton() {
@@ -1643,15 +1663,20 @@ import "./field_agent";
 				return;
 			}
 
+			const deletionEnabled = this.isConversationDeletionEnabled();
+
 			recentConversations.forEach((conversation) => {
-				const itemEl = document.createElement("button");
-				itemEl.type = "button";
-				itemEl.className = "ask_alyf-history-item btn btn-secondary btn-sm";
-				itemEl.dataset.conversation = conversation.name;
+				const itemEl = document.createElement("div");
+				itemEl.className = "ask_alyf-history-item";
+
+				const mainEl = document.createElement("button");
+				mainEl.type = "button";
+				mainEl.className = "ask_alyf-history-item-main btn btn-secondary btn-sm";
+				mainEl.dataset.conversation = conversation.name;
 
 				if (conversation.name === currentName) {
-					itemEl.classList.remove("btn-secondary");
-					itemEl.classList.add("btn-primary");
+					mainEl.classList.remove("btn-secondary");
+					mainEl.classList.add("btn-primary");
 				}
 
 				const titleEl = document.createElement("div");
@@ -1663,9 +1688,25 @@ import "./field_agent";
 				const timestampLabel = this.formatConversationTimestamp(conversation);
 				metaEl.textContent = timestampLabel || "";
 
-				itemEl.appendChild(titleEl);
-				itemEl.appendChild(metaEl);
-				itemEl.addEventListener("click", (event) => this.onHistoryConversationClick(event));
+				mainEl.appendChild(titleEl);
+				mainEl.appendChild(metaEl);
+				mainEl.addEventListener("click", (event) => this.onHistoryConversationClick(event));
+				itemEl.appendChild(mainEl);
+
+				if (deletionEnabled) {
+					const deleteEl = document.createElement("button");
+					deleteEl.type = "button";
+					deleteEl.className =
+						"ask_alyf-history-item-delete ask_alyf-icon-button btn btn-secondary btn-sm";
+					deleteEl.title = __("Delete conversation");
+					deleteEl.setAttribute("aria-label", __("Delete conversation"));
+					deleteEl.innerHTML = getIcon("trash", "sm", "", true);
+					deleteEl.addEventListener("click", (event) =>
+						this.onHistoryConversationDeleteClick(event, conversation.name),
+					);
+					itemEl.appendChild(deleteEl);
+				}
+
 				this.historyListEl.appendChild(itemEl);
 			});
 		}
@@ -2083,6 +2124,30 @@ import "./field_agent";
 			this.setLoading(false);
 			this.refreshConversationList();
 			this.setStatus("");
+		}
+
+		async deleteConversation(conversationName) {
+			if (!this.isConversationDeletionEnabled()) {
+				return;
+			}
+
+			const name = (conversationName || this.state.conversation?.name || "").toString();
+			if (!name) {
+				return;
+			}
+
+			await frappe.call({
+				method: "ask_alyf.api.delete_conversation",
+				type: "POST",
+				args: { conversation: name },
+			});
+
+			if (name === this.state.conversation?.name) {
+				await this.startNewConversation();
+				return;
+			}
+
+			this.refreshConversationList();
 		}
 
 		isFrontendAction(operation) {


### PR DESCRIPTION
## What this adds

- Implemented the `delete_conversation` API method to allow users to delete conversations.
- Updated settings to include `allow_conversation_deletion` option.
- Enhanced frontend to support conversation deletion with confirmation prompts and UI updates.
- Adjusted CSS for conversation history items to accommodate new delete button functionality.
- Prevents deletion while a job is running

Solves #14 

## Tests

1. test_delete_conversation_refuses_while_job_is_running
Blocks deletion while a background job is still running (user message with background_job_id, no assistant reply yet). Expects ValidationError and the conversation to remain.

2. test_delete_conversation_succeeds_when_idle
Allows deletion when the conversation is idle (user + assistant messages present). Expects {"success": True} and the doc to be removed.

3. test_process_message_job_skips_save_when_conversation_was_deleted
If the conversation is deleted mid-job, the background worker exits cleanly and does not write an assistant reply back.