### PR TITLE
feat: search compendium

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Optional tools:
 
 - `run_read_only_sql` runs read-only SQL for Administrator and System Manager users
 - `get_app_version`, `read_github_releases`, and `read_documentation_page` help answer app and documentation questions
+- `search_compendium` and `read_compendium_page` are registered only when the **Compendium** app is installed. They search the docs of all installed apps and read out the pages the user may read
 
 ### Subagents
 

--- a/ask_alyf/ask_alyf/agent.py
+++ b/ask_alyf/ask_alyf/agent.py
@@ -116,8 +116,15 @@ def _tool_call_label(name: str, args: Any) -> str:
 		return _("Reading instructions") if name == "read_skill" else _("Saving instructions")
 	if name in ("get_file_id", "read_file_record", "extract_document_data"):
 		return _("Reading the attached document")
-	if name in ("get_app_version", "read_github_releases", "read_documentation_page"):
+	if name in (
+		"get_app_version",
+		"read_github_releases",
+		"read_documentation_page",
+		"read_compendium_page",
+	):
 		return _("Reading documentation")
+	if name == "search_compendium":
+		return _("Searching the documentation")
 	if name in ("ls", "read_file", "glob", "grep"):
 		return _("Searching the source code")
 	if name == "task":
@@ -410,6 +417,9 @@ Mode awareness and behavior:
 			self.toolset.read_github_releases,
 			self.toolset.read_documentation_page,
 		]
+
+		if "compendium" in frappe.get_installed_apps():
+			tool_defs.extend([self.toolset.search_compendium, self.toolset.read_compendium_page])
 
 		if self.runtime.mode == "Agent":
 			if self._can_write_skill():

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -789,6 +789,7 @@ class UnitTestCodeTools(UnitTestCase):
 		# a wider snippet than the Awesome Bar's, because the model picks from it
 		self.assertEqual(search.call_args.kwargs["snippet_tokens"], tools.COMPENDIUM_SNIPPET_TOKENS)
 
+	@unittest.skipUnless(importlib.util.find_spec("compendium"), "compendium is not installed")
 	def test_compendium_search_without_searchable_words_finds_nothing(self):
 		with (
 			patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]),

--- a/ask_alyf/ask_alyf/test_code_tools.py
+++ b/ask_alyf/ask_alyf/test_code_tools.py
@@ -1,8 +1,10 @@
 import asyncio
 import contextlib
 import contextvars
+import importlib.util
 import itertools
 import threading
+import unittest
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import Any
@@ -757,6 +759,72 @@ class UnitTestCodeTools(UnitTestCase):
 		self.assertTrue(proposal_tools.issubset(agent_tool_names))
 		# No host filesystem, shell, or direct execution capability leaks in.
 		self.assertFalse(host_mutation_tools.intersection(agent_tool_names))
+
+	def test_compendium_tools_are_registered_only_when_the_app_is_installed(self):
+		compendium_tools = {"search_compendium", "read_compendium_page"}
+		runner = self.make_runner(allow_code_search=False)
+
+		with patch("frappe.get_installed_apps", return_value=["frappe"]):
+			names = {tool.__name__ for tool in runner._build_tools()}
+			self.assertFalse(compendium_tools.intersection(names))
+
+		with patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]):
+			names = {tool.__name__ for tool in runner._build_tools()}
+			self.assertTrue(compendium_tools.issubset(names))
+
+	@unittest.skipUnless(importlib.util.find_spec("compendium"), "compendium is not installed")
+	def test_compendium_search_returns_the_best_hits_up_to_the_limit(self):
+		hits = [("setup", "Setup", "…set up…"), ("billing", "Billing", "…"), ("faq", "FAQ", "…")]
+
+		with (
+			patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]),
+			patch("compendium.docs.normalize_locale", return_value="en"),
+			patch("compendium.search.search", return_value=hits) as search,
+		):
+			found = tools.search_compendium("how do I set up billing", limit=2)
+
+		self.assertEqual([hit["title"] for hit in found], ["Setup", "Billing"])
+		self.assertEqual(found[0]["snippet"], "…set up…")
+		self.assertEqual(found[0]["route"], "/app/docs/en/setup")
+		# a wider snippet than the Awesome Bar's, because the model picks from it
+		self.assertEqual(search.call_args.kwargs["snippet_tokens"], tools.COMPENDIUM_SNIPPET_TOKENS)
+
+	def test_compendium_search_without_searchable_words_finds_nothing(self):
+		with (
+			patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]),
+			patch("compendium.docs.normalize_locale", return_value="en"),
+		):
+			self.assertEqual(tools.search_compendium("   "), [])
+
+	@unittest.skipUnless(importlib.util.find_spec("compendium"), "compendium is not installed")
+	def test_a_long_compendium_page_is_read_out_in_slices(self):
+		body = "x" * (tools.MAX_COMPENDIUM_PAGE_CHARS + 10)
+		page = frappe._dict(path="setup", title="Setup", body=body)
+
+		with (
+			patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]),
+			patch("compendium.docs.normalize_locale", return_value="en"),
+			patch("compendium.docs.get_page_record", return_value=page) as get_page_record,
+		):
+			first = tools.read_compendium_page("setup")
+			rest = tools.read_compendium_page("setup", offset=first["next_offset"])
+
+		self.assertEqual(len(first["content"]), tools.MAX_COMPENDIUM_PAGE_CHARS)
+		self.assertEqual(first["next_offset"], tools.MAX_COMPENDIUM_PAGE_CHARS)
+		self.assertEqual(len(rest["content"]), 10)
+		self.assertIsNone(rest["next_offset"])
+		self.assertEqual(rest["total_chars"], len(body))
+		# the body is read out here, so permission is checked here
+		self.assertTrue(all(call.kwargs["check_permission"] for call in get_page_record.call_args_list))
+
+	@unittest.skipUnless(importlib.util.find_spec("compendium"), "compendium is not installed")
+	def test_a_compendium_path_that_escapes_the_docs_folder_is_rejected(self):
+		with (
+			patch("frappe.get_installed_apps", return_value=["frappe", "compendium"]),
+			patch("compendium.docs.normalize_locale", return_value="en"),
+			self.assertRaises(frappe.ValidationError),
+		):
+			tools.read_compendium_page("../../../etc/passwd")
 
 	def test_ask_mode_tools_exclude_all_write_proposals_and_host_mutation(self):
 		host_mutation_tools = {"write_file", "edit_file", "execute", "shell", "run_shell"}

--- a/ask_alyf/ask_alyf/tools.py
+++ b/ask_alyf/ask_alyf/tools.py
@@ -53,6 +53,12 @@ VISION_MIME_TYPES = {
 }
 MAX_VISION_PAGES = 10
 VISION_DPI = 200
+# How much of a docs page one read returns. A longer page is read on in a
+# second call, from the offset the first one reported.
+MAX_COMPENDIUM_PAGE_CHARS = 6000
+# Wider than the Awesome Bar's snippet: the model picks which page to read
+# from it, where a user picks from the title.
+COMPENDIUM_SNIPPET_TOKENS = 60
 DEFAULT_DOCUMENT_EXTRACTION_PROMPT = (
 	"Extract all structured data from this document. "
 	"Use clearly labeled fields and include all text, tables, amounts, dates, names, "
@@ -1092,6 +1098,62 @@ def read_github_releases(app_name: str, limit: int = 5) -> list[dict[str, Any]]:
 		}
 		for item in payload
 	]
+
+
+def get_compendium_locale() -> str:
+	"""The docs locale for this request, and the guard that Compendium is installed."""
+	if "compendium" not in frappe.get_installed_apps():
+		frappe.throw(_("The Compendium app is not installed."))
+
+	from compendium import docs
+
+	return docs.normalize_locale(frappe.local.lang or docs.DEFAULT_LANG)
+
+
+def search_compendium(query: str, limit: int = 10) -> list[dict[str, Any]]:
+	locale = get_compendium_locale()
+
+	from compendium import search
+
+	match_query = search.build_match_query(query)
+	if not match_query:
+		return []
+
+	limit = coerce_int(limit, 10, minimum=1)
+
+	# `search` returns only pages this user may read, best match first.
+	return [
+		{
+			"path": path,
+			"title": title,
+			"snippet": snippet,
+			"route": f"/app/docs/{locale}/{path}" if path else f"/app/docs/{locale}",
+		}
+		for path, title, snippet in search.search(
+			locale, match_query, snippet_tokens=COMPENDIUM_SNIPPET_TOKENS
+		)[:limit]
+	]
+
+
+def read_compendium_page(path: str, offset: int = 0) -> dict[str, Any]:
+	locale = get_compendium_locale()
+
+	from compendium import docs
+
+	# `normalize_path` rejects the traversal a model could put in `path`.
+	page = docs.get_page_record(docs.normalize_path(path), locale=locale, check_permission=True)
+	body = page.body or ""
+	offset = coerce_int(offset, 0, minimum=0)
+	content = body[offset : offset + MAX_COMPENDIUM_PAGE_CHARS]
+
+	return {
+		"path": page.path,
+		"title": page.title,
+		"content": content,
+		"offset": offset,
+		"next_offset": offset + len(content) if offset + len(content) < len(body) else None,
+		"total_chars": len(body),
+	}
 
 
 def read_documentation_page(app_name: str, relative_path: str = "") -> dict[str, Any]:

--- a/ask_alyf/ask_alyf/toolset.py
+++ b/ask_alyf/ask_alyf/toolset.py
@@ -703,6 +703,37 @@ class ask_alyfToolset:
 		"""
 		return tools.read_documentation_page(app_name=app_name, relative_path=relative_path)
 
+	def search_compendium(self, query: str, limit: int = 10) -> list[dict[str, Any]]:
+		"""Search the documentation this site serves through the Compendium app.
+
+		Prefer this over `read_documentation_page` for how-to and configuration
+		questions: it searches the docs shipped with all installed apps. Read the
+		promising hits with `read_compendium_page`.
+
+		Args:
+			query: Free text to search for.
+			limit: Maximum number of hits to return.
+
+		Returns:
+			A list of hits, best match first, each with its path, title, a short
+			snippet, and the Desk route the page can be opened at.
+		"""
+		return tools.search_compendium(query=query, limit=limit)
+
+	def read_compendium_page(self, path: str, offset: int = 0) -> dict[str, Any]:
+		"""Read a documentation page found with `search_compendium`.
+
+		Args:
+			path: The page path as returned by `search_compendium`.
+			offset: Character offset to read from. Pass the `next_offset` of the
+				previous read to continue through a page that did not fit.
+
+		Returns:
+			The page title and a slice of its content, with the offset to continue
+			at in `next_offset` (None when the page ends here).
+		"""
+		return tools.read_compendium_page(path=path, offset=offset)
+
 	def read_skill(self, name: str) -> dict[str, str]:
 		"""Read the full content of an Ask ALYF skill available to the current user.
 


### PR DESCRIPTION
## Why

The agent could only reach documentation over the network: `read_documentation_page` resolves an app's `documentation` URL from its `pyproject.toml` and fetches it. On a site that serves its docs through [Compendium](https://github.com/alyf-de/compendium), those same pages are already on disk, already indexed in FTS5, and already filtered by role — and the agent had no way to read them. So questions the docs answer ("how do I set this up") fell back to guessing from DocType metadata.

## What changed

Two tools, registered in `_build_tools` only when `compendium` is in the installed apps:

- **`search_compendium(query, limit=10)`** — runs the query through Compendium's `build_match_query` and `search`, and returns the hits (`path`, `title`, `snippet`, Desk `route`), best match first. The snippet is asked for at 60 tokens rather than the Awesome Bar's 12: the model picks which page to read from the snippet, where a person picks from the title.
- **`read_compendium_page(path, offset=0)`** — returns `MAX_COMPENDIUM_PAGE_CHARS` (6000) of the page from `offset`, plus `next_offset` and `total_chars`. A page that does not fit is read on in a second call from the offset the first one reported, so a long page never lands in the context in one piece.

Search and read are separate on purpose: a search that returned whole pages would spend the context of every hit the model then discards.

Both tools go through Compendium's own functions, so nothing about docs discovery, locale fallback or permissions is reimplemented here:

- the locale is `docs.normalize_locale(frappe.local.lang)`, so the agent reads the same page the user would see;
- `search` already drops pages the user's roles do not allow, and `get_page_record(check_permission=True)` checks again where the body is actually read out;
- `docs.normalize_path` rejects the traversal a model could put in `path`.

Also: step labels for both tools ("Searching the documentation" / "Reading documentation") and a README line under _Optional tools_.

Requires Compendium with the configurable `snippet_tokens` parameter (`refactor: make snippet_tokens configurable in search`, in 15.2.0).

## Test

`bench --site test-site-dev run-tests --app ask_alyf` — 146 unit + 17 integration tests pass.

New tests cover: registration only when the app is installed, hits limited and snippet width passed through, a blank query searching nothing, a long page read out in slices, and a traversing path rejected.
